### PR TITLE
simplify bootstrap profiles to only point at single upstream project; this will ensure no duplicate GAVs when building the whole stack

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
 		<profile>
 			<id>bootstrap</id>
 			<modules>
-				<module>../base</module>
+				<module>../server</module>
 			</modules>
 		</profile>
 	</profiles>


### PR DESCRIPTION
...is will ensure no duplicate GAVs when building the whole stack
