### PR TITLE
JBIDE-13076 Marker Resolution Generators should check if IMarker exists

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/action/JSPProblemMarkerResolutionGenerator.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/action/JSPProblemMarkerResolutionGenerator.java
@@ -378,11 +378,9 @@ public class JSPProblemMarkerResolutionGenerator implements IMarkerResolutionGen
 
 	@Override
 	public boolean hasResolutions(IMarker marker) {
-		try{
-			String message = (String)marker.getAttribute(IMarker.MESSAGE);
+		if(marker.exists()){
+			String message = marker.getAttribute(IMarker.MESSAGE, "");
 			return message.startsWith(UNKNOWN_TAG) || message.startsWith(MISSING_ATTRIBUTE);
-		}catch(CoreException ex){
-			WebUiPlugin.getPluginLog().logError(ex);
 		}
 		return false;
 	}


### PR DESCRIPTION
Added if(marker.exists()) to method public boolean hasResolutions(IMarker marker)
