### PR TITLE
JBIDE-13367 NullPointerException in FaceletPageContextImpl.getExternalVars

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/AbstractXmlCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/AbstractXmlCompletionProposalComputer.java
@@ -33,8 +33,10 @@ import org.eclipse.wst.xml.core.internal.regions.DOMRegionContext;
 import org.eclipse.wst.xml.ui.internal.contentassist.AbstractXMLModelQueryCompletionProposalComputer;
 import org.eclipse.wst.xml.ui.internal.contentassist.ContentAssistRequest;
 import org.jboss.tools.common.el.core.resolver.ELContext;
+import org.jboss.tools.jst.jsp.JspEditorPlugin;
 import org.jboss.tools.jst.web.kb.IPageContext;
 import org.jboss.tools.jst.web.kb.KbQuery;
+import org.jboss.tools.jst.web.kb.PageContextFactory;
 import org.jboss.tools.jst.web.kb.KbQuery.Type;
 import org.jboss.tools.jst.web.kb.internal.KbProject;
 import org.w3c.dom.Attr;
@@ -113,6 +115,16 @@ abstract public class AbstractXmlCompletionProposalComputer extends AbstractXMLM
 	 */
 	abstract protected ELContext createContext();
 
+	protected final ELContext createContext(String contextType) {
+		IDocument document = getDocument();
+		IFile file = PageContextFactory.getResource(document);
+		if(file == null) {
+			//Report the illegal state and finish nicely without content assist crash.
+			JspEditorPlugin.getPluginLog().logError(new IllegalStateException("Cannot find existing file by its document."));
+			return null;
+		}
+		return PageContextFactory.createPageContext(document, file, contextType, false);
+	}
 	/**
 	 * Returns the <code>org.jboss.tools.jst.web.kb.KbQuery</code> instance. The prefix and URI for the tags 
 	 * are calculated from the current node

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/FaceletsELCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/FaceletsELCompletionProposalComputer.java
@@ -124,7 +124,7 @@ public class FaceletsELCompletionProposalComputer extends JspELCompletionProposa
 	 */
 	@Override
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.FACELETS_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.FACELETS_PAGE_CONTEXT_TYPE);
 	}
 
 	/*

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/FaceletsTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/FaceletsTagCompletionProposalComputer.java
@@ -124,7 +124,7 @@ public class FaceletsTagCompletionProposalComputer extends JspTagCompletionPropo
 	 */
 	@Override
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.FACELETS_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.FACELETS_PAGE_CONTEXT_TYPE);
 	}
 
 	/*

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspELCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspELCompletionProposalComputer.java
@@ -48,7 +48,7 @@ public class JspELCompletionProposalComputer extends XmlELCompletionProposalComp
 	 */
 	@Override
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.JSP_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.JSP_PAGE_CONTEXT_TYPE);
 	}
 
 	/*

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspTagCompletionProposalComputer.java
@@ -50,7 +50,7 @@ public class JspTagCompletionProposalComputer extends XmlTagCompletionProposalCo
 	 */
 	@Override
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.JSP_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.JSP_PAGE_CONTEXT_TYPE);
 	}
 
 	/*

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlELCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlELCompletionProposalComputer.java
@@ -550,12 +550,12 @@ public class XmlELCompletionProposalComputer extends AbstractXmlCompletionPropos
 	 * @return
 	 */
 	protected boolean isELCAToBeShown() {
-		ELResolver[] resolvers =  getContext().getElResolvers();
+		ELResolver[] resolvers = getContext() == null ? null : getContext().getElResolvers();
 		return (resolvers != null && resolvers.length > 0);
 	}
 
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.XML_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.XML_PAGE_CONTEXT_TYPE);
 	}
 	
 	protected KbQuery createKbQuery(Type type, String query, String stringQuery) {

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
@@ -501,7 +501,7 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 	}
 
 	protected ELContext createContext() {
-		return PageContextFactory.createPageContext(getDocument(), PageContextFactory.XML_PAGE_CONTEXT_TYPE);
+		return createContext(PageContextFactory.XML_PAGE_CONTEXT_TYPE);
 	}
 	
 	protected KbQuery createKbQuery(Type type, String query, String stringQuery) {

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
@@ -515,7 +515,11 @@ public class PageContextFactory implements IResourceChangeListener {
 			if (sModel != null) {
 				String baseLocation = sModel.getBaseLocation();
 				IPath location = new Path(baseLocation).makeAbsolute();
-				return FileBuffers.getWorkspaceFileAtLocation(location);
+				IFile result = FileBuffers.getWorkspaceFileAtLocation(location);
+				if(result != null) {
+					//JBIDE-13367 wtp may return wrong location.
+					return result;
+				}
 			}
 		}
 		finally {


### PR DESCRIPTION
Completion proposal computers should check if file can be found
by the available document. If not, log illegal state error,
but content assist should not crush.
