### PR TITLE
JBIDE-13400 - PageContextFactory.ExtendedLinkElementAdapter is leaked

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
@@ -1039,7 +1039,7 @@ public class PageContextFactory implements IResourceChangeListener {
 		synchronized (notifier) {
 			IStyleSheetAdapter adapter = (IStyleSheetAdapter) notifier.getAdapterFor(IStyleSheetAdapter.class);
 
-			if (!(adapter instanceof ExtendedLinkElementAdapter)) {
+			if (adapter != null && !(adapter instanceof ExtendedLinkElementAdapter)) {
 				notifier.removeAdapter(adapter);
 				adapter = new ExtendedLinkElementAdapter(
 						(Element) stylesContainer, attribute, jsf2Source);


### PR DESCRIPTION
https://issues.jboss.org/browse/JBIDE-13400
PageContextFactory.ExtendedLinkElementAdapter is leaked
