### PR TITLE
JBIDE-12175 Automatic namespace completion in Facelets files

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.jspeditor.dnd;
 
@@ -18,7 +18,6 @@ import java.util.Properties;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
-import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.ui.IEditorPart;
@@ -28,7 +27,6 @@ import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
 import org.eclipse.wst.sse.core.internal.provisional.IndexedRegion;
 import org.eclipse.wst.sse.core.internal.provisional.StructuredModelManager;
 import org.eclipse.wst.sse.core.internal.provisional.text.IStructuredDocument;
-import org.eclipse.wst.sse.ui.internal.contentassist.ContentAssistUtils;
 import org.eclipse.wst.xml.core.internal.document.DocumentImpl;
 import org.eclipse.wst.xml.core.internal.document.ElementImpl;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
@@ -50,7 +48,7 @@ public class PaletteTaglibInserter {
 	private static final String JSP_SOURCE_ROOT_ELEMENT = "jsp:root"; //$NON-NLS-1$
 	public static final String JSP_URI = "http://java.sun.com/JSP/Page"; //$NON-NLS-1$
 	public static final String faceletUri = "http://java.sun.com/jsf/facelets"; //$NON-NLS-1$
-
+	
 	private static final String TAGLIB_START = "<%@ taglib";  //$NON-NLS-1$
 
 	public Properties inserTaglib(IDocument d, Properties p) {
@@ -89,12 +87,13 @@ public class PaletteTaglibInserter {
 
 			String uri_p = p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI);
 			String defaultPrefix_p = p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX);
+			boolean forcePrefix = "true".equalsIgnoreCase(p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_FORCE_PREFIX));
 			String lineDelimiter = PaletteInsertHelper.getLineDelimiter(d);
 			StringBuffer tg = new StringBuffer(TAGLIB_START).append(" uri=\"").append(uri_p).append("\"").append(" prefix=\"").append(defaultPrefix_p).append("\"%>").append(lineDelimiter); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
 			if (tl != null && !tl.isEmpty()) {
 				//If taglib already exist check the prefix if changed
-				if (tl.containsKey(uri_p)) {
+				if (!forcePrefix && tl.containsKey(uri_p)) {
 					if (!tl.get(uri_p).equals(defaultPrefix_p)) {
 						p.setProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX, (String)tl.get(uri_p));
 					}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/IKbProject.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/IKbProject.java
@@ -16,6 +16,7 @@ import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.IPath;
 import org.jboss.tools.common.validation.IProjectValidationContext;
 import org.jboss.tools.jst.web.kb.include.IIncludeModel;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
 /**
@@ -66,4 +67,10 @@ public interface IKbProject extends IProjectNature {
 	 * @return model object that collects <ui:include> elements from pages
 	 */
 	IIncludeModel getIncludeModel();
+	
+	/**
+	 * 
+	 * @return model object that collects data from xmlns:* attributes of pages.
+	 */
+	INameSpaceStorage getNameSpaceStorage();
 }

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/KbProject.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/KbProject.java
@@ -60,6 +60,7 @@ import org.jboss.tools.jst.web.kb.require.KbRequireBuilder;
 import org.jboss.tools.jst.web.kb.require.KbRequireDefinition;
 import org.jboss.tools.jst.web.kb.taglib.ICompositeTagLibrary;
 import org.jboss.tools.jst.web.kb.taglib.ICustomTagLibrary;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 import org.w3c.dom.Element;
 
@@ -94,6 +95,8 @@ public class KbProject extends KbObject implements IKbProject {
 	Map<String, Object> extensionModels = new HashMap<String, Object>();
 
 	IncludeModel includeModel = new IncludeModel();
+
+	NameSpaceStorage namespacesStorage = new NameSpaceStorage(this);
 
 	public KbProject() {}
 
@@ -144,6 +147,10 @@ public class KbProject extends KbObject implements IKbProject {
 
 	public IIncludeModel getIncludeModel() {
 		return includeModel;
+	}
+
+	public INameSpaceStorage getNameSpaceStorage() {
+		return namespacesStorage;
 	}
 
 	/*
@@ -356,6 +363,7 @@ public class KbProject extends KbObject implements IKbProject {
 			if(root != null) {
 				getValidationContext().load(root);
 				includeModel.load(root);
+				namespacesStorage.load(root);
 			}
 
 		} finally {
@@ -462,6 +470,7 @@ public class KbProject extends KbObject implements IKbProject {
 
 			if(validationContext != null) validationContext.store(root);
 			includeModel.store(root);
+			namespacesStorage.store(root);
 		
 			XMLUtilities.serialize(root, file.getAbsolutePath());
 		

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/NameSpaceStorage.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/NameSpaceStorage.java
@@ -1,0 +1,122 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.jst.web.kb.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.tools.common.model.project.ext.store.XMLStoreConstants;
+import org.jboss.tools.common.xml.XMLUtilities;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
+import org.w3c.dom.Element;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class NameSpaceStorage implements INameSpaceStorage {
+	KbProject project;
+	private Map<String, Set<String>> urisByPrefix = new HashMap<String, Set<String>>();
+
+	public NameSpaceStorage(KbProject project) {
+		this.project = project;
+	}
+
+	public synchronized void add(String prefix, String uri) {
+		Set<String> uris = urisByPrefix.get(prefix);
+		if(uris == null || !uris.contains(uri)) {
+			//new uri, check that it exists
+			if(project.getTagLibraries(uri).length == 0) {
+				return;
+			}
+		}
+		if(uris == null) {
+			uris = new HashSet<String>();
+			urisByPrefix.put(prefix, uris);
+		}
+		uris.add(uri);
+	}
+
+	public synchronized Set<String> getURIs(String prefix) {
+		Set<String> result = new HashSet<String>();
+		Set<String> urls = urisByPrefix.get(prefix);
+		if(urls != null) {
+			result.addAll(urls);
+		}
+		return result;
+	}
+
+	public synchronized Set<String> getPrefixes(String prefixMask) {
+		Set<String> result = new HashSet<String>();
+		for (String prefix: urisByPrefix.keySet()) {
+			if(prefix.startsWith(prefixMask)) {
+				Set<String> urls = urisByPrefix.get(prefix);
+				if(!urls.isEmpty()) {
+					result.add(prefix);
+				}
+			}
+		}
+		return result;
+	}
+
+	static final String ELEMENT_URIS = "uris";
+	static final String ELEMENT_URI = "uri";
+	static final String ELEMENT_PREFIX = "prefix";
+
+	public synchronized void store(Element root) {
+		Element urisElement = XMLUtilities.createElement(root, ELEMENT_URIS);
+		Map<String, Set<String>> uris = revert();
+		for (String uri: uris.keySet()) {
+			Element uriElement = XMLUtilities.createElement(urisElement, ELEMENT_URI);
+			uriElement.setAttribute(XMLStoreConstants.ATTR_VALUE, uri);
+			Set<String> prefixes = uris.get(uri);
+			for (String prefix: prefixes) {
+				Element prefixElement = XMLUtilities.createElement(uriElement, ELEMENT_PREFIX);
+				prefixElement.setTextContent(prefix);
+			}
+		}
+	}
+
+	public synchronized void load(Element root) {
+		Element urisElement = XMLUtilities.getUniqueChild(root, ELEMENT_URIS);
+		if(urisElement != null) {
+			for (Element uriElement: XMLUtilities.getChildren(urisElement, ELEMENT_URI)) {
+				String uri = uriElement.getAttribute(XMLStoreConstants.ATTR_VALUE);
+				for (Element prefixElement: XMLUtilities.getChildren(uriElement, ELEMENT_PREFIX)) {
+					String prefix = prefixElement.getTextContent();
+					if(prefix != null && uri != null && prefix.length() > 0 && uri.length() > 0) {
+						add(prefix, uri);
+					}
+				}
+			}
+		}
+	}
+
+	private Map<String, Set<String>> revert() {
+		Map<String, Set<String>> result = new HashMap<String, Set<String>>();
+		for (String prefix: urisByPrefix.keySet()) {
+			Set<String> uris = urisByPrefix.get(prefix);
+			for (String uri: uris) {
+				Set<String> prefixes = result.get(uri);
+				if(prefixes == null) {
+					prefixes = new HashSet<String>();
+					result.put(uri, prefixes);
+				}
+				prefixes.add(prefix);
+			}
+		}
+		return result;
+	}
+
+}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/INameSpaceStorage.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/INameSpaceStorage.java
@@ -1,0 +1,48 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.jst.web.kb.taglib;
+
+import java.util.Set;
+
+/**
+ * 
+ * Keeps data from xmlns:* attributes.
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public interface INameSpaceStorage {
+	
+	/**
+	 * Adds to the storage data from xmlns:%prefix%="%url%" attribute on a page.
+	 * 
+	 * @param prefix
+	 * @param url
+	 */
+	public void add(String prefix, String uri);
+	
+	/**
+	 * Returns all uris declared with given prefix on pages in the current project.
+	 * 
+	 * @param prefix
+	 * @return
+	 */
+	public Set<String> getURIs(String prefix);
+
+	/**
+	 * Returns all prefixes, starting with prefixMask, 
+	 * declared on pages in the current project.
+	 * 
+	 * @param prefixMask
+	 * @return
+	 */
+	public Set<String> getPrefixes(String prefixMask);
+}


### PR DESCRIPTION
Implemented name space storage for user defined namespaces.
Automatic namespace completion is added for the namespaces that are not
defined within the page:
- xmlns:*-attribute names
- xmlns:*-attribute values
- tags having a prefix that is not defined within the page
  All the default prefixes of the Tag Libraries and the custom user defined prefixes are
  taken into account.
