### PR TITLE
JBIDE-12175 Automatic namespace completion in Facelets files

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.jspeditor.dnd;
 
@@ -18,7 +18,6 @@ import java.util.Properties;
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.jface.text.ITextSelection;
-import org.eclipse.jface.text.ITextViewer;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.viewers.ISelectionProvider;
 import org.eclipse.ui.IEditorPart;
@@ -28,7 +27,6 @@ import org.eclipse.wst.sse.core.internal.provisional.IStructuredModel;
 import org.eclipse.wst.sse.core.internal.provisional.IndexedRegion;
 import org.eclipse.wst.sse.core.internal.provisional.StructuredModelManager;
 import org.eclipse.wst.sse.core.internal.provisional.text.IStructuredDocument;
-import org.eclipse.wst.sse.ui.internal.contentassist.ContentAssistUtils;
 import org.eclipse.wst.xml.core.internal.document.DocumentImpl;
 import org.eclipse.wst.xml.core.internal.document.ElementImpl;
 import org.eclipse.wst.xml.core.internal.provisional.document.IDOMDocument;
@@ -50,7 +48,7 @@ public class PaletteTaglibInserter {
 	private static final String JSP_SOURCE_ROOT_ELEMENT = "jsp:root"; //$NON-NLS-1$
 	public static final String JSP_URI = "http://java.sun.com/JSP/Page"; //$NON-NLS-1$
 	public static final String faceletUri = "http://java.sun.com/jsf/facelets"; //$NON-NLS-1$
-
+	
 	private static final String TAGLIB_START = "<%@ taglib";  //$NON-NLS-1$
 
 	public Properties inserTaglib(IDocument d, Properties p) {
@@ -89,12 +87,13 @@ public class PaletteTaglibInserter {
 
 			String uri_p = p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI);
 			String defaultPrefix_p = p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX);
+			boolean forcePrefix = "true".equalsIgnoreCase(p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_FORCE_PREFIX));
 			String lineDelimiter = PaletteInsertHelper.getLineDelimiter(d);
 			StringBuffer tg = new StringBuffer(TAGLIB_START).append(" uri=\"").append(uri_p).append("\"").append(" prefix=\"").append(defaultPrefix_p).append("\"%>").append(lineDelimiter); //$NON-NLS-1$ //$NON-NLS-2$ //$NON-NLS-3$ //$NON-NLS-4$
 
 			if (tl != null && !tl.isEmpty()) {
 				//If taglib already exist check the prefix if changed
-				if (tl.containsKey(uri_p)) {
+				if (!forcePrefix && tl.containsKey(uri_p)) {
 					if (!tl.get(uri_p).equals(defaultPrefix_p)) {
 						p.setProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX, (String)tl.get(uri_p));
 					}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/IKbProject.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/IKbProject.java
@@ -16,6 +16,7 @@ import org.eclipse.core.resources.IProjectNature;
 import org.eclipse.core.runtime.IPath;
 import org.jboss.tools.common.validation.IProjectValidationContext;
 import org.jboss.tools.jst.web.kb.include.IIncludeModel;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
 /**
@@ -66,4 +67,10 @@ public interface IKbProject extends IProjectNature {
 	 * @return model object that collects <ui:include> elements from pages
 	 */
 	IIncludeModel getIncludeModel();
+	
+	/**
+	 * 
+	 * @return model object that collects data from xmlns:* attributes of pages.
+	 */
+	INameSpaceStorage getNameSpaceStorage();
 }

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/KbProject.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/KbProject.java
@@ -60,6 +60,7 @@ import org.jboss.tools.jst.web.kb.require.KbRequireBuilder;
 import org.jboss.tools.jst.web.kb.require.KbRequireDefinition;
 import org.jboss.tools.jst.web.kb.taglib.ICompositeTagLibrary;
 import org.jboss.tools.jst.web.kb.taglib.ICustomTagLibrary;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 import org.w3c.dom.Element;
 
@@ -94,6 +95,8 @@ public class KbProject extends KbObject implements IKbProject {
 	Map<String, Object> extensionModels = new HashMap<String, Object>();
 
 	IncludeModel includeModel = new IncludeModel();
+
+	NameSpaceStorage namespacesStorage = new NameSpaceStorage(this);
 
 	public KbProject() {}
 
@@ -144,6 +147,10 @@ public class KbProject extends KbObject implements IKbProject {
 
 	public IIncludeModel getIncludeModel() {
 		return includeModel;
+	}
+
+	public INameSpaceStorage getNameSpaceStorage() {
+		return namespacesStorage;
 	}
 
 	/*
@@ -356,6 +363,7 @@ public class KbProject extends KbObject implements IKbProject {
 			if(root != null) {
 				getValidationContext().load(root);
 				includeModel.load(root);
+				namespacesStorage.load(root);
 			}
 
 		} finally {
@@ -462,6 +470,7 @@ public class KbProject extends KbObject implements IKbProject {
 
 			if(validationContext != null) validationContext.store(root);
 			includeModel.store(root);
+			namespacesStorage.store(root);
 		
 			XMLUtilities.serialize(root, file.getAbsolutePath());
 		

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/NameSpaceStorage.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/NameSpaceStorage.java
@@ -1,0 +1,122 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.jst.web.kb.internal;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.jboss.tools.common.model.project.ext.store.XMLStoreConstants;
+import org.jboss.tools.common.xml.XMLUtilities;
+import org.jboss.tools.jst.web.kb.taglib.INameSpaceStorage;
+import org.w3c.dom.Element;
+
+/**
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public class NameSpaceStorage implements INameSpaceStorage {
+	KbProject project;
+	private Map<String, Set<String>> urisByPrefix = new HashMap<String, Set<String>>();
+
+	public NameSpaceStorage(KbProject project) {
+		this.project = project;
+	}
+
+	public synchronized void add(String prefix, String uri) {
+		Set<String> uris = urisByPrefix.get(prefix);
+		if(uris == null || !uris.contains(uri)) {
+			//new uri, check that it exists
+			if(project.getTagLibraries(uri).length == 0) {
+				return;
+			}
+		}
+		if(uris == null) {
+			uris = new HashSet<String>();
+			urisByPrefix.put(prefix, uris);
+		}
+		uris.add(uri);
+	}
+
+	public synchronized Set<String> getURIs(String prefix) {
+		Set<String> result = new HashSet<String>();
+		Set<String> urls = urisByPrefix.get(prefix);
+		if(urls != null) {
+			result.addAll(urls);
+		}
+		return result;
+	}
+
+	public synchronized Set<String> getPrefixes(String prefixMask) {
+		Set<String> result = new HashSet<String>();
+		for (String prefix: urisByPrefix.keySet()) {
+			if(prefix.startsWith(prefixMask)) {
+				Set<String> urls = urisByPrefix.get(prefix);
+				if(!urls.isEmpty()) {
+					result.add(prefix);
+				}
+			}
+		}
+		return result;
+	}
+
+	static final String ELEMENT_URIS = "uris";
+	static final String ELEMENT_URI = "uri";
+	static final String ELEMENT_PREFIX = "prefix";
+
+	public synchronized void store(Element root) {
+		Element urisElement = XMLUtilities.createElement(root, ELEMENT_URIS);
+		Map<String, Set<String>> uris = revert();
+		for (String uri: uris.keySet()) {
+			Element uriElement = XMLUtilities.createElement(urisElement, ELEMENT_URI);
+			uriElement.setAttribute(XMLStoreConstants.ATTR_VALUE, uri);
+			Set<String> prefixes = uris.get(uri);
+			for (String prefix: prefixes) {
+				Element prefixElement = XMLUtilities.createElement(uriElement, ELEMENT_PREFIX);
+				prefixElement.setTextContent(prefix);
+			}
+		}
+	}
+
+	public synchronized void load(Element root) {
+		Element urisElement = XMLUtilities.getUniqueChild(root, ELEMENT_URIS);
+		if(urisElement != null) {
+			for (Element uriElement: XMLUtilities.getChildren(urisElement, ELEMENT_URI)) {
+				String uri = uriElement.getAttribute(XMLStoreConstants.ATTR_VALUE);
+				for (Element prefixElement: XMLUtilities.getChildren(uriElement, ELEMENT_PREFIX)) {
+					String prefix = prefixElement.getTextContent();
+					if(prefix != null && uri != null && prefix.length() > 0 && uri.length() > 0) {
+						add(prefix, uri);
+					}
+				}
+			}
+		}
+	}
+
+	private Map<String, Set<String>> revert() {
+		Map<String, Set<String>> result = new HashMap<String, Set<String>>();
+		for (String prefix: urisByPrefix.keySet()) {
+			Set<String> uris = urisByPrefix.get(prefix);
+			for (String uri: uris) {
+				Set<String> prefixes = result.get(uri);
+				if(prefixes == null) {
+					prefixes = new HashSet<String>();
+					result.put(uri, prefixes);
+				}
+				prefixes.add(prefix);
+			}
+		}
+		return result;
+	}
+
+}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/INameSpaceStorage.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/INameSpaceStorage.java
@@ -1,0 +1,48 @@
+/******************************************************************************* 
+ * Copyright (c) 2013 Red Hat, Inc. 
+ * Distributed under license by Red Hat, Inc. All rights reserved. 
+ * This program is made available under the terms of the 
+ * Eclipse Public License v1.0 which accompanies this distribution, 
+ * and is available at http://www.eclipse.org/legal/epl-v10.html 
+ * 
+ * Contributors: 
+ * Red Hat, Inc. - initial API and implementation 
+ ******************************************************************************/ 
+package org.jboss.tools.jst.web.kb.taglib;
+
+import java.util.Set;
+
+/**
+ * 
+ * Keeps data from xmlns:* attributes.
+ * 
+ * @author Viacheslav Kabanovich
+ *
+ */
+public interface INameSpaceStorage {
+	
+	/**
+	 * Adds to the storage data from xmlns:%prefix%="%url%" attribute on a page.
+	 * 
+	 * @param prefix
+	 * @param url
+	 */
+	public void add(String prefix, String uri);
+	
+	/**
+	 * Returns all uris declared with given prefix on pages in the current project.
+	 * 
+	 * @param prefix
+	 * @return
+	 */
+	public Set<String> getURIs(String prefix);
+
+	/**
+	 * Returns all prefixes, starting with prefixMask, 
+	 * declared on pages in the current project.
+	 * 
+	 * @param prefixMask
+	 * @return
+	 */
+	public Set<String> getPrefixes(String prefixMask);
+}

--- a/tests/org.jboss.tools.jst.jsp.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jst.jsp.test/META-INF/MANIFEST.MF
@@ -21,7 +21,8 @@ Require-Bundle: org.junit,
  org.eclipse.jst.standard.schemas,
  org.eclipse.e4.core.commands;bundle-version="0.10.1",
  org.eclipse.e4.core.contexts;bundle-version="1.1.0",
- org.eclipse.e4.ui.bindings;bundle-version="0.10.1"
+ org.eclipse.e4.ui.bindings;bundle-version="0.10.1",
+ org.jboss.tools.common.el.core;bundle-version="3.4.0"
 Export-Package: 
  org.jboss.tools.jst.jsp.test,
  org.jboss.tools.jst.jsp.test.ca

--- a/tests/org.jboss.tools.jst.jsp.test/projects/Jbide6061Test/WebContent/pages/prefixes.xhtml
+++ b/tests/org.jboss.tools.jst.jsp.test/projects/Jbide6061Test/WebContent/pages/prefixes.xhtml
@@ -1,0 +1,7 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"
+      xmlns:custom1="http://java.sun.com/jsf/html"
+      xmlns:custom2="http://java.sun.com/jsf/html"
+      xmlns:custom3="http://java.sun.com/jsf/html"
+      xmlns:custom4="http://java.sun.com/jsf/html">
+</html>

--- a/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/JstJspAllTests.java
+++ b/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/JstJspAllTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2007-2012 Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -17,6 +17,7 @@ import org.jboss.tools.jst.jsp.test.ca.CAMultipleCSSClassesInsertionTest;
 import org.jboss.tools.jst.jsp.test.ca.Jbide1791Test;
 import org.jboss.tools.jst.jsp.test.ca.Jbide6061Test;
 import org.jboss.tools.jst.jsp.test.ca.Jbide9092Test;
+import org.jboss.tools.jst.jsp.test.ca.JstCAOnCustomPrefixesTest;
 import org.jboss.tools.jst.jsp.test.ca.JstJspJbide1585Test;
 import org.jboss.tools.jst.jsp.test.ca.JstJspJbide1641Test;
 import org.jboss.tools.jst.jsp.test.ca.JstJspNonAutomaticProposalInsertionTest;
@@ -31,7 +32,8 @@ public class JstJspAllTests {
 		suite.addTest(new ProjectImportTestSetup(new TestSuite(
 				KeyBindingsTest.class,
 				Jbide6061Test.class,
-				CAMultipleCSSClassesInsertionTest.class),
+				CAMultipleCSSClassesInsertionTest.class,
+				JstCAOnCustomPrefixesTest.class),
 				"org.jboss.tools.jst.jsp.test", "projects/Jbide6061Test", //$NON-NLS-1$ //$NON-NLS-2$
 				"Jbide6061Test")); //$NON-NLS-1$
 

--- a/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/ca/JstCAOnCustomPrefixesTest.java
+++ b/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/ca/JstCAOnCustomPrefixesTest.java
@@ -1,0 +1,219 @@
+/*******************************************************************************
+ * Copyright (c) 2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.jsp.test.ca;
+
+import java.util.List;
+
+import junit.framework.Test;
+import junit.framework.TestSuite;
+
+import org.eclipse.core.resources.IFile;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.jboss.tools.common.base.test.contentassist.CATestUtil;
+import org.jboss.tools.jst.jsp.contentassist.AutoContentAssistantProposal;
+import org.jboss.tools.jst.web.kb.PageContextFactory;
+import org.jboss.tools.test.util.ProjectImportTestSetup;
+import org.jboss.tools.test.util.TestProjectProvider;
+
+
+/**
+* Test case testing http://jira.jboss.com/jira/browse/JBIDE-12175 issue.
+* 
+* @author Victor Rubezhny
+*
+*/
+public class JstCAOnCustomPrefixesTest  extends ContentAssistantTestCase {
+	TestProjectProvider provider = null;
+	boolean makeCopy = false;
+	private static final String PROJECT_NAME = "Jbide6061Test"; //$NON-NLS-1$
+	private static final String PAGE_NAME = "/WebContent/pages/xhtml_page.xhtml"; //$NON-NLS-1$
+	private static final String PREFIXES_PAGE_NAME = "/WebContent/pages/prefixes.xhtml"; //$NON-NLS-1$
+	private static final String TAG_OPEN_STRING = "<"; //$NON-NLS-1$
+	private static final String PREFIX_STRING = "custom1:commandBu"; //$NON-NLS-1$
+	private static final String TAG_PROPOSAL_TO_FIND = "custom1:commandButton"; //$NON-NLS-1$
+	private static final String TAG_INSERTION_STRING = TAG_OPEN_STRING + PREFIX_STRING;
+	private static final String PREFIX2_STRING = "custom2:commandBu"; //$NON-NLS-1$
+	private static final String TAG2_PROPOSAL_TO_FIND = "custom2:commandButton"; //$NON-NLS-1$
+	private static final String TAG2_XNLNS_TO_FIND = "xmlns:custom2=\"http://java.sun.com/jsf/html\"";
+	private static final String TAG2_INSERTION_STRING = TAG_OPEN_STRING + PREFIX2_STRING;
+	private static final String XMLNS_ATTRIBUTE_INSERTION_STRING = "xmlns:"; //$NON-NLS-1$
+	private static final String[] XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND = {
+				"xmlns:custom1=\"http://java.sun.com/jsf/html\"", //$NON-NLS-1$
+				"xmlns:custom2=\"http://java.sun.com/jsf/html\"", //$NON-NLS-1$
+				"xmlns:custom3=\"http://java.sun.com/jsf/html\"", //$NON-NLS-1$
+				"xmlns:custom4=\"http://java.sun.com/jsf/html\"" //$NON-NLS-1$
+		};
+	private static final String CUSTOM_ATTRIBUTE_VALUE_INSERTION_STRING = "xmlns:custom3=\""; //$NON-NLS-1$
+	private static final String CUSTOM_ATTRIBUTE_VALUE_PROPOSAL_TO_FIND = "\"http://java.sun.com/jsf/html\""; //$NON-NLS-1$
+
+	public static Test suite() {
+		return new TestSuite(JstCAOnCustomPrefixesTest.class);
+	}
+
+	public void setUp() throws Exception {
+		project = ProjectImportTestSetup.loadProject(PROJECT_NAME);
+		IFile file = project.getFile(PREFIXES_PAGE_NAME);
+		PageContextFactory.createPageContext(file);
+	}
+	
+	public void testCAOnCustomPrefixForTag() {
+		openEditor(PAGE_NAME);
+		
+		// Find start of <f:view> tag
+		String documentContent = document.get();
+		int start = (documentContent == null ? -1 : documentContent.indexOf("<f:view")); //$NON-NLS-1$
+		int offsetToTest = start + TAG_INSERTION_STRING.length();
+		
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		
+		String documentContentModified = documentContent.substring(0, start) +
+			TAG_INSERTION_STRING + documentContent.substring(start);
+		
+		jspTextEditor.setText(documentContentModified);
+		
+		try {
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), new String[] {TAG_PROPOSAL_TO_FIND});
+		} finally {
+			closeEditor();
+		}
+	}
+
+	public void testCAOnCustomPrefixForTagInsertion() {
+		openEditor(PAGE_NAME);
+		
+		// Find start of <f:view> tag
+		String documentContent = document.get();
+		int start = (documentContent == null ? -1 : documentContent.indexOf("<f:view")); //$NON-NLS-1$
+		int offsetToTest = start + TAG2_INSERTION_STRING.length();
+		
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		
+		String documentContentModified = documentContent.substring(0, start) +
+			TAG2_INSERTION_STRING + documentContent.substring(start);
+		
+		jspTextEditor.setText(documentContentModified);
+		
+		try {
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), new String[] {TAG2_PROPOSAL_TO_FIND});
+			
+			boolean found = false;
+			for (ICompletionProposal p : res) {
+				if (!(p instanceof AutoContentAssistantProposal))
+					continue;
+				
+				AutoContentAssistantProposal proposal = (AutoContentAssistantProposal)p;
+	            if(proposal.getDisplayString().equals(TAG2_PROPOSAL_TO_FIND)){
+	                found = true;
+	                proposal.apply(viewer, '\0', 0, proposal.getReplacementOffset());
+	                break;
+	            }
+			}
+			assertTrue("Cannot find the requested proposal among the proposals returned by the Content Assisant", found); //$NON-NLS-1$
+			
+			documentContent = document.get(); // Get the updated document content
+			int htmlStart = (documentContent == null ? -1 : documentContent.indexOf("<html")); //$NON-NLS-1$
+			// Find end of <html> tag attributes
+			int htmlEnd = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
+			String htmlTagContent = documentContent.substring(htmlStart, htmlEnd + 1);
+			
+			assertTrue("Cannot find the '" + TAG2_XNLNS_TO_FIND + "' attribute/value in <html> tag!", (htmlTagContent.indexOf(TAG2_XNLNS_TO_FIND) != -1));
+			
+		} finally {
+			closeEditor();
+		}
+	}
+
+	public void testCAOnCustomPrefixForXMLNSAttribute() {
+		openEditor(PAGE_NAME);
+		
+		// Find start of <html> tag
+		String documentContent = document.get();
+		int start = (documentContent == null ? -1 : documentContent.indexOf("<html")); //$NON-NLS-1$
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		// Find end of <html> tag attributes
+		start = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		
+		int offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING.length();
+		
+		String documentContentModified = documentContent.substring(0, start) + ' ' +
+			XMLNS_ATTRIBUTE_INSERTION_STRING + ' ' + documentContent.substring(start);
+		
+		jspTextEditor.setText(documentContentModified);
+		
+		try {
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND);
+		} finally {
+			closeEditor();
+		}
+	}
+
+	public void testCAOnCustomPrefixForXMLNSAttributeValue() {
+		openEditor(PAGE_NAME);
+		
+		// Find start of <html> tag
+		String documentContent = document.get();
+		int start = (documentContent == null ? -1 : documentContent.indexOf("<html")); //$NON-NLS-1$
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		// Find end of <html> tag attributes
+		start = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
+		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+		
+		int offsetToTest = start + 1 + CUSTOM_ATTRIBUTE_VALUE_INSERTION_STRING.length();
+		
+		String documentContentModified = documentContent.substring(0, start) + ' ' +
+			CUSTOM_ATTRIBUTE_VALUE_INSERTION_STRING + ' ' + documentContent.substring(start);
+		
+		jspTextEditor.setText(documentContentModified);
+		
+		try {
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), new String[] {CUSTOM_ATTRIBUTE_VALUE_PROPOSAL_TO_FIND});
+		} finally {
+			closeEditor();
+		}
+	}
+
+    private void checkResult(ICompletionProposal[] rst, String[] proposals) {
+        for ( int i = 0 ; i < proposals.length ; i ++ ){
+           assertTrue("Should be in proposals list",isInResultList(rst,proposals[i])); //$NON-NLS-1$
+        }
+        
+    }
+
+    private boolean isInResultList(ICompletionProposal[] rst, String string) {
+        boolean r = false;
+        
+        for(ICompletionProposal cp:rst){
+            if(cp.getDisplayString().equals(string)){
+                r = true;
+                break;
+            }
+        }
+        return r;
+    }
+
+}


### PR DESCRIPTION
Implemented name space storage for user defined namespaces.
Automatic namespace completion is added for the namespaces that are not
defined within the page:
- xmlns:*-attribute names
- xmlns:*-attribute values
- tags having a prefix that is not defined within the page
  All the default prefixes of the Tag Libraries and the custom user defined prefixes are
  taken into account.
  JUnit Test is added due to verify the issue:
-  tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/ca/JstCAOnCustomPrefixesTest.java
