### PR TITLE
JBIDE-13455 Code completion for tag names throws NPE

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
@@ -713,6 +713,9 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 
 		public void run(IProgressMonitor monitor)
 				throws InvocationTargetException, InterruptedException {
+			if (uri == null || prefix == null) // No need to add a namespace in case of no prefix/uri is specified
+				return;
+			
 			Properties properties = new Properties();
 			
 			properties.put(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, "true"); //$NON-NLS-1$


### PR DESCRIPTION
Issue is fixed. No need to add a namespace if no uri/prefix specified, so the namespace adding is just skipped in case of no uri or prefix is specified.
JUnit Test cannot be made for such case because it is too hard to emulate the typing of a text into the editor while Content Assist window is opened to
make Content Assist window to filter out existing proposals dynamically.
