### PR TITLE
JBIDE-13451 Too many "xmlns:"-proposals when requesting content assist f...

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
@@ -98,6 +98,8 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 	public static final String HTML_TAGNAME = "html"; //$NON-NLS-1$
 	public static final String XMLNS_ATTRIBUTE_NAME_PREFIX = "xmlns:"; //$NON-NLS-1$
 	public static final String EMPTY_ATTRIBUTE_VALUE = "=\"\""; //$NON-NLS-1$
+	private static final String XMLNS_ATTRIBUTE_NAME = "xmlns"; //$NON-NLS-1$
+	private static final String XMLNS_ATTRIBUTE_VALUE = "http://www.w3.org/1999/xhtml"; //$NON-NLS-1$
 	protected static final ICompletionProposal[] EMPTY_PROPOSAL_LIST = new ICompletionProposal[0];
 	
 	@Override
@@ -222,6 +224,9 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 		} else if (XMLNS_ATTRIBUTE_NAME_PREFIX.startsWith(attrName)){
 			prefixBeginning = "";
 		}
+		
+		if (!isExistingAttribute(XMLNS_ATTRIBUTE_NAME, XMLNS_ATTRIBUTE_VALUE) && !attrName.startsWith(XMLNS_ATTRIBUTE_NAME_PREFIX))
+			return;
 		
 		IFile file = PageContextFactory.getResource(context.getDocument());
 		if (file != null && file.getProject() != null) {
@@ -490,6 +495,16 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 	 * @param attrName Name of attribute to check
 	 */
 	protected boolean isExistingAttribute(String attrName) {
+		return isExistingAttribute(attrName, null);
+	}
+	
+	
+	/*
+	 * Checks if the specified attribute exists 
+	 * 
+	 * @param attrName Name of attribute to check
+	 */
+	protected boolean isExistingAttribute(String attrName, String value) {
 		IStructuredModel sModel = StructuredModelManager.getModelManager()
 				.getExistingModelForRead(getDocument());
 		try {
@@ -524,7 +539,16 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 			if (n == null)
 				return false;
 
-			return (((Element)n).getAttributeNode(attrName) != null);
+			Attr a = ((Element)n).getAttributeNode(attrName);
+			if (a == null)
+				return false;
+			
+			if (value == null)
+				return true;
+			
+			String v = Utils.trimQuotes(a.getNodeValue());
+			
+			return (v != null && v.equalsIgnoreCase(Utils.trimQuotes(value)));
 		} finally {
 			if (sModel != null) {
 				sModel.releaseFromRead();

--- a/plugins/org.jboss.tools.jst.web.kb/taglibs/Facelets.xml
+++ b/plugins/org.jboss.tools.jst.web.kb/taglibs/Facelets.xml
@@ -19,12 +19,6 @@
 				create an instance for you and set it on your JavaBean before
 				continuing with building the tree.</description>
 		</attribute>
-		<attribute extended="false" name="xmlns">
-			<proposal type="taglib" />
-		</attribute>
-		<attribute extended="false" name="xmlns:*">
-			<proposal type="taglib" />
-		</attribute>
 	</component>
 	<component name="composition" extended="false">
 		<attribute extended="false" name="template">
@@ -34,12 +28,6 @@
 			<proposal type="file">
 				<param name="extensions" value="%page%" />
 			</proposal>
-		</attribute>
-		<attribute extended="false" name="xmlns">
-			<proposal type="taglib" />
-		</attribute>
-		<attribute extended="false" name="xmlns:*">
-			<proposal type="taglib" />
 		</attribute>
 	</component>
 	<component closeTag="true" name="debug" extended="false">
@@ -83,12 +71,6 @@
 				<param name="extensions" value="%page%" />
 			</proposal>
 		</attribute>
-		<attribute extended="false" name="xmlns">
-			<proposal type="taglib" />
-		</attribute>
-		<attribute extended="false" name="xmlns:*">
-			<proposal type="taglib" />
-		</attribute>
 	</component>
 	<component name="define" extended="false">
 		<description>The define tag can be used within tags that allow
@@ -121,12 +103,6 @@
 				UIComponent instance assigned already, JavaServer Faces will lazily
 				create an instance for you and set it on your JavaBean before
 				continuing with building the tree.</description>
-		</attribute>
-		<attribute extended="false" name="xmlns">
-			<proposal type="taglib" />
-		</attribute>
-		<attribute extended="false" name="xmlns:*">
-			<proposal type="taglib" />
 		</attribute>
 	</component>
 	<component closeTag="true" name="include" extended="false">

--- a/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/ca/JstCAOnCustomPrefixesTest.java
+++ b/tests/org.jboss.tools.jst.jsp.test/src/org/jboss/tools/jst/jsp/test/ca/JstCAOnCustomPrefixesTest.java
@@ -45,6 +45,7 @@ public class JstCAOnCustomPrefixesTest  extends ContentAssistantTestCase {
 	private static final String TAG2_XNLNS_TO_FIND = "xmlns:custom2=\"http://java.sun.com/jsf/html\"";
 	private static final String TAG2_INSERTION_STRING = TAG_OPEN_STRING + PREFIX2_STRING;
 	private static final String XMLNS_ATTRIBUTE_INSERTION_STRING = "xmlns:"; //$NON-NLS-1$
+	private static final String XMLNS_ATTRIBUTE_INSERTION_STRING_2 = "xmln"; //$NON-NLS-1$
 	private static final String[] XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND = {
 				"xmlns:custom1=\"http://java.sun.com/jsf/html\"", //$NON-NLS-1$
 				"xmlns:custom2=\"http://java.sun.com/jsf/html\"", //$NON-NLS-1$
@@ -53,7 +54,13 @@ public class JstCAOnCustomPrefixesTest  extends ContentAssistantTestCase {
 		};
 	private static final String CUSTOM_ATTRIBUTE_VALUE_INSERTION_STRING = "xmlns:custom3=\""; //$NON-NLS-1$
 	private static final String CUSTOM_ATTRIBUTE_VALUE_PROPOSAL_TO_FIND = "\"http://java.sun.com/jsf/html\""; //$NON-NLS-1$
-
+	private static final String WRONG_TAG_PREFIX = "ui:composition"; //$NON-NLS-1$
+	private static final String WRONG_TAG_INSERTION_STRING = TAG_OPEN_STRING + WRONG_TAG_PREFIX;
+	private static final String[] WRONG_TAG_ATTRIBUTE_PROPOSALS_TO_FIND = {
+				"xmlns", //$NON-NLS-1$
+				"xmlns:*", //$NON-NLS-1$
+		};
+	
 	public static Test suite() {
 		return new TestSuite(JstCAOnCustomPrefixesTest.class);
 	}
@@ -139,30 +146,127 @@ public class JstCAOnCustomPrefixesTest  extends ContentAssistantTestCase {
 		}
 	}
 
-	public void testCAOnCustomPrefixForXMLNSAttribute() {
+	public void testCAOnCustomPrefixForXMLNSAttributeOnRootTag() {
 		openEditor(PAGE_NAME);
 		
-		// Find start of <html> tag
-		String documentContent = document.get();
-		int start = (documentContent == null ? -1 : documentContent.indexOf("<html")); //$NON-NLS-1$
-		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
-		// Find end of <html> tag attributes
-		start = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
-		assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
-		
-		int offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING.length();
-		
-		String documentContentModified = documentContent.substring(0, start) + ' ' +
-			XMLNS_ATTRIBUTE_INSERTION_STRING + ' ' + documentContent.substring(start);
-		
-		jspTextEditor.setText(documentContentModified);
-		
-		try {
+		try {		
+			// Find start of <html> tag
+			String documentContent = document.get();
+			int start = (documentContent == null ? -1 : documentContent.indexOf("<html")); //$NON-NLS-1$
+			assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+			// Find end of <html> tag attributes
+			start = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
+			assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+
+			//
+			// On a Root Tags the "xmlns:" proposals should be shown for any prefix part (xmlns:...)
+			//
+			int offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING.length();
+			
+			String documentContentModified = documentContent.substring(0, start) + ' ' +
+				XMLNS_ATTRIBUTE_INSERTION_STRING + ' ' + documentContent.substring(start);
+			
+			jspTextEditor.setText(documentContentModified);
+
 			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
 	
 			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
 			
 			checkResult(res.toArray(new ICompletionProposal[0]), XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND);
+
+			//
+			// On a Root Tags the "xmlns:" proposals should be shown for any prefix part
+			//
+			offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING_2.length();
+			documentContentModified = documentContent.substring(0, start) + ' ' +
+				XMLNS_ATTRIBUTE_INSERTION_STRING_2 + ' ' + documentContent.substring(start);
+			
+			jspTextEditor.setText(documentContentModified);
+			
+			res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+			
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND);
+		} finally {
+			closeEditor();
+		}
+	}
+
+	public void testCAOnCustomPrefixForXMLNSAttributeOnNotARootTag() {
+		openEditor(PAGE_NAME);
+		
+		try {		
+			// Find start of <h:inputText> tag
+			String documentContent = document.get();
+			int start = (documentContent == null ? -1 : documentContent.indexOf("<h:inputText")); //$NON-NLS-1$
+			assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+			// Find end of <h:inputText> tag attributes
+			start = (documentContent == null ? -1 : documentContent.indexOf(">", start)); //$NON-NLS-1$
+			assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+			
+			//
+			// On non-Root Tags the "xmlns:" proposals should be shown only is prefix has "xmlns:" beginning
+			//
+			int offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING.length();
+			
+			String documentContentModified = documentContent.substring(0, start) + ' ' +
+				XMLNS_ATTRIBUTE_INSERTION_STRING + ' ' + documentContent.substring(start);
+			
+			jspTextEditor.setText(documentContentModified);
+
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", (res != null && res.size() > 0)); //$NON-NLS-1$
+			
+			checkResult(res.toArray(new ICompletionProposal[0]), XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND);
+
+			//
+			// On non-Root Tags the "xmlns:" proposals should be shown only is prefix has "xmlns:" beginning
+			// If there is no "xmlns:" prefix is typed in then no "xmlns:"-proposals should be shown
+			//
+			offsetToTest = start + 1 + XMLNS_ATTRIBUTE_INSERTION_STRING_2.length();
+			documentContentModified = documentContent.substring(0, start) + ' ' +
+				XMLNS_ATTRIBUTE_INSERTION_STRING_2 + ' ' + documentContent.substring(start);
+			
+			jspTextEditor.setText(documentContentModified);
+			
+			res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+			
+			assertTrue("Content Assistant returned no proposals", res != null); //$NON-NLS-1$
+			
+			if (res.size() > 0)
+				checkFalseResult(res.toArray(new ICompletionProposal[0]), XMLNS_ATTRIBUTE_PROPOSALS_TO_FIND);
+		} finally {
+			closeEditor();
+		}
+	}
+
+	public void testCAOnCustomPrefixForXMLNSWrongAttributes() {
+		openEditor(PAGE_NAME);
+		
+		try {		
+			// Find start of <h:inputText> tag
+			String documentContent = document.get();
+			int start = (documentContent == null ? -1 : documentContent.indexOf("<h:inputText")); //$NON-NLS-1$
+			assertTrue("Cannot find the starting point in the test file  \"" + PAGE_NAME + "\"", (start != -1)); //$NON-NLS-1$ //$NON-NLS-2$
+			
+			//
+			// There should be neither 'xmlns', nor 'xmlns:*' tag attribute proposals
+			//
+			int offsetToTest = start + WRONG_TAG_INSERTION_STRING.length() + 1;
+			
+			String documentContentModified = documentContent.substring(0, start) + 
+				WRONG_TAG_INSERTION_STRING + "  " + documentContent.substring(start);
+			
+			jspTextEditor.setText(documentContentModified);
+
+			List<ICompletionProposal> res = CATestUtil.collectProposals(contentAssistant, viewer, offsetToTest);
+	
+			assertTrue("Content Assistant returned no proposals", res != null); //$NON-NLS-1$
+			
+			if (res.size() > 0)
+				checkFalseResult(res.toArray(new ICompletionProposal[0]), WRONG_TAG_ATTRIBUTE_PROPOSALS_TO_FIND);
 		} finally {
 			closeEditor();
 		}
@@ -204,10 +308,19 @@ public class JstCAOnCustomPrefixesTest  extends ContentAssistantTestCase {
         
     }
 
+    private void checkFalseResult(ICompletionProposal[] rst, String[] proposals) {
+        for ( int i = 0 ; i < proposals.length ; i ++ ){
+           assertFalse("Should not be in proposals list",isInResultList(rst,proposals[i])); //$NON-NLS-1$
+        }
+        
+    }
+
     private boolean isInResultList(ICompletionProposal[] rst, String string) {
         boolean r = false;
-        
+
+        System.out.println("isInResultList: ");
         for(ICompletionProposal cp:rst){
+        	System.out.println(">>> " + cp.getDisplayString() + " =?= " + string);
             if(cp.getDisplayString().equals(string)){
                 r = true;
                 break;


### PR DESCRIPTION
...or tag attribute name

Issue is fixed.
Wrong extra non-iconified 'xmnls'-attribute proposals are removed from the <ui:component />, <ui:composition />, <ui:decorate /> and <ui:fragment /> tags.
JUnit Test org.jboss.tools.jst.jsp.test.ca.JstCAOnCustomPrefixesTest is updated due to valudate the issue.
