### PR TITLE
JBIDE-13489 org.jboss.tools.jst.jsp fails to build against 4.3.0.M5

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
@@ -435,7 +435,7 @@ public class JavaStringELInfoHover extends JavadocHover {
 						reader= new StringReader(ELInfoHoverMessages.ELInfoHover_noInformation);
 
 				} else {
-					base= JavaDocLocations.getBaseURL(member);
+					base= JavaDocLocations.getBaseURL(member, member.isBinary());
 				}
 
 			} catch (JavaModelException ex) {


### PR DESCRIPTION
Compilation error is fixed.

```
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
```
