### PR TITLE
(JBIDE-13400) PageContextFactory.ExtendedLinkElementAdapter is leaked

### DIFF
--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSJSPRecognizer.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSJSPRecognizer.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007-2010 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 package org.jboss.tools.jst.css.dialog.selector.model;
 
@@ -68,8 +68,11 @@ public class CSSJSPRecognizer {
 		java.util.List<CSSRuleList> cssRuleLists = new ArrayList<CSSRuleList>(0);
 		styleSheets = new ArrayList<CSSStyleSheet>(0);
 		for (int i = 0; i < descrs.size(); i++) {
-			styleSheets.add(descrs.get(i).sheet);
-			cssRuleLists.add(descrs.get(i).sheet.getCssRules());
+			CSSStyleSheet sheet = descrs.get(i).getStylesheet();
+			if (sheet != null) {
+				styleSheets.add(sheet);
+				cssRuleLists.add(sheet.getCssRules());
+			}
 		}
 		if (cssRuleLists.size() == 0) {
 			return null;

--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSSelectorTreeModel.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSSelectorTreeModel.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007-2010 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 
 package org.jboss.tools.jst.css.dialog.selector.model;
@@ -39,25 +39,27 @@ public class CSSSelectorTreeModel {
 
 	private void initModel(CSSStyleSheetDescriptor[] cssStyleSheets) {
 		for (int i = 0; i < cssStyleSheets.length; i++) {
-			CSSStyleSheet styleSheet = cssStyleSheets[i].sheet;
-			CSSTreeNode parentSheet = new CSSTreeNode(cssStyleSheets[i].source);
-			parentSheet.setStyleSheetSource(parentSheet.toString());
-			invisibleRoot.addChild(parentSheet);
-			parentSheet.setCSSContainer(new CSSStyleSheetContainer(styleSheet,
-					cssStyleSheets[i].source));
-			CSSRuleList cssRuleList = styleSheet.getCssRules();
-			for (int j = 0; j < cssRuleList.getLength(); j++) {
-				CSSRule cssRule = cssRuleList.item(j);
-				if (cssRule.getType() == CSSRule.STYLE_RULE) {
-					String[] selectors = CSSSelectorUtils
-						.parseSelectorName(((ICSSStyleRule) cssRule)
-								.getSelectorText());
-					for (int k = 0; k < selectors.length; k++) {
-						CSSTreeNode ruleNode = new CSSTreeNode(selectors[k]);
-						ruleNode.setCSSContainer(new CSSRuleContainer(selectors[k],
-							cssRule, cssStyleSheets[i].source));
-						ruleNode.setStyleSheetSource(cssStyleSheets[i].source);
-						parentSheet.addChild(ruleNode);
+			CSSStyleSheet styleSheet = cssStyleSheets[i].getStylesheet();
+			if (styleSheet != null) {
+				CSSTreeNode parentSheet = new CSSTreeNode(cssStyleSheets[i].getSource());
+				parentSheet.setStyleSheetSource(parentSheet.toString());
+				invisibleRoot.addChild(parentSheet);
+				parentSheet.setCSSContainer(new CSSStyleSheetContainer(styleSheet,
+						cssStyleSheets[i].getSource()));
+				CSSRuleList cssRuleList = styleSheet.getCssRules();
+				for (int j = 0; j < cssRuleList.getLength(); j++) {
+					CSSRule cssRule = cssRuleList.item(j);
+					if (cssRule.getType() == CSSRule.STYLE_RULE) {
+						String[] selectors = CSSSelectorUtils
+							.parseSelectorName(((ICSSStyleRule) cssRule)
+									.getSelectorText());
+						for (int k = 0; k < selectors.length; k++) {
+							CSSTreeNode ruleNode = new CSSTreeNode(selectors[k]);
+							ruleNode.setCSSContainer(new CSSRuleContainer(selectors[k],
+								cssRule, cssStyleSheets[i].getSource()));
+							ruleNode.setStyleSheetSource(cssStyleSheets[i].getSource());
+							parentSheet.addChild(ruleNode);
+						}
 					}
 				}
 			}

--- a/plugins/org.jboss.tools.jst.text.ext/src/org/jboss/tools/jst/text/ext/hyperlink/CSSClassHyperlink.java
+++ b/plugins/org.jboss.tools.jst.text.ext/src/org/jboss/tools/jst/text/ext/hyperlink/CSSClassHyperlink.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011-2012 Red Hat, Inc.
+ * Copyright (c) 2011-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -53,6 +53,7 @@ import org.w3c.dom.css.CSSMediaRule;
 import org.w3c.dom.css.CSSRule;
 import org.w3c.dom.css.CSSRuleList;
 import org.w3c.dom.css.CSSStyleRule;
+import org.w3c.dom.css.CSSStyleSheet;
 
 /**
  * @author Jeremy
@@ -82,12 +83,15 @@ public class CSSClassHyperlink extends AbstractHyperlink {
 		
 		for (int i = (descrs == null) ? -1 : descrs.size() - 1; descrs != null && i >= 0; i--) {
 			CSSStyleSheetDescriptor descr = descrs.get(i);
-			CSSRuleList rules = descr.sheet.getCssRules();
-			for (int r = 0; rules != null && r < rules.getLength(); r++) {
-				Set<CSSRuleDescriptor> matches = getMatchedRuleDescriptors(rules.item(r), getStyleName(region));
-				for (CSSRuleDescriptor match : matches) {
-					match.stylesheetDescriptor = descr;
-					bestMatchDescriptors.add(match);
+			CSSStyleSheet sheet = descr.getStylesheet();
+			if (sheet != null) {
+				CSSRuleList rules = sheet.getCssRules();
+				for (int r = 0; rules != null && r < rules.getLength(); r++) {
+					Set<CSSRuleDescriptor> matches = getMatchedRuleDescriptors(rules.item(r), getStyleName(region));
+					for (CSSRuleDescriptor match : matches) {
+						match.stylesheetDescriptor = descr;
+						bestMatchDescriptors.add(match);
+					}
 				}
 			}
 		}
@@ -100,16 +104,17 @@ public class CSSClassHyperlink extends AbstractHyperlink {
 			IFile file = findFileForCSSStyleSheet(descr.getFilePath());
 			if (file != null) {
 				int startOffset = 0;
-				if (descr.sheet.getOwnerNode() != null) {
-					Node node = descr.sheet.getOwnerNode().getFirstChild();
+				CSSStyleSheet sheet = descr.getStylesheet();
+				if (sheet != null && descr.getContainerNode() != null) {
+					Node node = descr.getContainerNode().getFirstChild();
 					if (node instanceof IndexedRegion) {
 						startOffset = ((IndexedRegion)node).getStartOffset();
 					}
+					showRegion(
+							file, 
+							new Region(startOffset + ((IndexedRegion)d.rule).getStartOffset(), ((IndexedRegion)d.rule).getLength()));
+					return;
 				}
-				showRegion(
-						file, 
-						new Region(startOffset + ((IndexedRegion)d.rule).getStartOffset(), ((IndexedRegion)d.rule).getLength()));
-				return;
 			}
 		}
 

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/proposal/CSSClassProposalType.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/proposal/CSSClassProposalType.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2009-2011 Red Hat, Inc. 
+ * Copyright (c) 2009-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -26,6 +26,7 @@ import org.w3c.dom.css.CSSMediaRule;
 import org.w3c.dom.css.CSSRule;
 import org.w3c.dom.css.CSSRuleList;
 import org.w3c.dom.css.CSSStyleRule;
+import org.w3c.dom.css.CSSStyleSheet;
 
 /**
  * The CSS Class proposal type. Is used to collect and return the proposals on
@@ -51,10 +52,13 @@ public class CSSClassProposalType extends CustomProposalType {
 			List<CSSStyleSheetDescriptor> descrs = cssSource.getCSSStyleSheetDescriptors();
 			if (descrs != null) {
 				for (CSSStyleSheetDescriptor descr : descrs) {
-					CSSRuleList rules = descr.sheet.getCssRules();
-					for (int i = 0; rules != null && i < rules.getLength(); i++) {
-						CSSRule rule = rules.item(i);
-						idList.addAll(getClassNamesFromCSSRule(rule));
+					CSSStyleSheet sheet = descr.getStylesheet();
+					if (sheet != null) {
+						CSSRuleList rules = sheet.getCssRules();
+						for (int i = 0; rules != null && i < rules.getLength(); i++) {
+							CSSRule rule = rules.item(i);
+							idList.addAll(getClassNamesFromCSSRule(rule));
+						}
 					}
 				}
 			}


### PR DESCRIPTION
The issue is fixed by avoiding the adding of ExtendedLinkElementAdapter to the nodes.
ExtendedLinkElementAdapter is used only on a temporary basis and as such no leaks should occur.

```
modified:   plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSJSPRecognizer.java
modified:   plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/selector/model/CSSSelectorTreeModel.java
modified:   plugins/org.jboss.tools.jst.text.ext/src/org/jboss/tools/jst/text/ext/hyperlink/CSSClassHyperlink.java
modified:   plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
modified:   plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/proposal/CSSClassProposalType.java
```
