### PR TITLE
JBIDE-13491 org.jboss.tools.jst.css.test.jbide.InputFractionalValueTest_JBIDE4790 test failure for Eclipse 4.3.0.M5

### DIFF
--- a/tests/org.jboss.tools.jst.css.test/src/org/jboss/tools/jst/css/test/jbide/InputFractionalValueTest_JBIDE4790.java
+++ b/tests/org.jboss.tools.jst.css.test/src/org/jboss/tools/jst/css/test/jbide/InputFractionalValueTest_JBIDE4790.java
@@ -30,6 +30,7 @@ import org.w3c.dom.css.CSSStyleRule;
  * @author Sergey Dzmitrovich
  * 
  */
+@SuppressWarnings("restriction")
 public class InputFractionalValueTest_JBIDE4790 extends AbstractCSSViewTest {
 
 	public static final String TEST_PAGE_NAME = "JBIDE/4790/inputFractional.css"; //$NON-NLS-1$
@@ -97,39 +98,27 @@ public class InputFractionalValueTest_JBIDE4790 extends AbstractCSSViewTest {
 
 		assertNotNull(testedValue);
 
-		/*
-		 * this test is negative for JBIDE-13380
-		 * TODO: after wtp team will fix their issue, test will fail
-		 * To fix it, uncomment assertion below.
-		 */
-		assertEquals(removeWhitespaces("1em 1.em 1.em"),
+		assertEquals(removeWhitespaces(newTestedValue),
 				removeWhitespaces(testedValue));
-		
-//		assertEquals(removeWhitespaces(newTestedValue),
-//				removeWhitespaces(testedValue));
 
 		parsedTestValue = Util.convertExtString(testedValue);
 
 		assertEquals(parsedTestValue.length, 2);
 
-		/*
-		 * https://jira.jboss.org/jira/browse/JBIDE-4790
-		 * TODO: JUnit should be updated after JBIDE-4790 fixing.
-		 */
-//		newTestedValue = parsedTestValue[0] + "3" + parsedTestValue[1]; //$NON-NLS-1$
-//		try {
-//			styleAttributes.put(TEST_CSS_ATTRIBUTE_NAME,
-//					newTestedValue);
-//		} catch (DOMException e) {
-//			fail("Changing of attribute's value leads to DOMException. Probably it is problem concerned with of JBIDE-4790 "); //$NON-NLS-1$
-//		}
-//		
-//		testedValue = declaration.getPropertyValue(TEST_CSS_ATTRIBUTE_NAME);
-//
-//		assertNotNull(testedValue);
-//
-//		assertEquals(removeWhitespaces(testedValue),
-//				removeWhitespaces(newTestedValue));
+		newTestedValue = removeWhitespaces(parsedTestValue[0]) + "3" + parsedTestValue[1]; //$NON-NLS-1$
+		try {
+			styleAttributes.put(TEST_CSS_ATTRIBUTE_NAME,
+					newTestedValue);
+		} catch (DOMException e) {
+			fail("Changing of attribute's value leads to DOMException. Probably it is problem concerned with of JBIDE-4790 "); //$NON-NLS-1$
+		}
+		
+		testedValue = declaration.getPropertyValue(TEST_CSS_ATTRIBUTE_NAME);
+
+		assertNotNull(testedValue);
+
+		assertEquals(removeWhitespaces(testedValue),
+				removeWhitespaces(newTestedValue));
 
 	}
 


### PR DESCRIPTION
issue is fully fixed in Alpha5 target platform
I make test back to normal(it was "negative").

Also I uncomment the part of test which was commented due to JBIDE-4790(I mark this issue in jira as resolved)
