### PR TITLE
JBIDE-13837 KB Builder does complete scanning of content of every jar file

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/scanner/LibraryScanner.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/scanner/LibraryScanner.java
@@ -107,11 +107,12 @@ public class LibraryScanner implements IFileScanner {
 				}
 			}
 		}
-		XModelObject[] ps = o.getChildren();
-		for (int i = 0; i < ps.length; i++) {
-			if(ps[i] == metaInf || ps[i].getFileType() != XModelObject.FOLDER) continue;
-			LoadedDeclarations ds1 = parseInPackages(ps[i], path, sp);
-			if(ds1 != null) ds.add(ds1);
+		if(o.getAttributeValue(XModelObjectConstants.ATTR_NAME).indexOf("jsf-impl") >= 0) {
+			XModelObject p = o.getChildByPath("com/sun/faces/metadata");
+			if(p != null && p.getFileType() == XModelObject.FOLDER) {
+				LoadedDeclarations ds1 = parseInPackages(p, path, sp);
+				if(ds1 != null) ds.add(ds1);
+			}
 		}
 
 		return ds;
@@ -179,4 +180,3 @@ public class LibraryScanner implements IFileScanner {
 	}
 	
 }
-


### PR DESCRIPTION
Looking into packages is limited to the specific case of jsf-impl*.jar.
