### PR TITLE
JBIDE-13864 Memory usage problem in PageContextFactory.CSSStyleSheetDesc...

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JspContextImpl.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JspContextImpl.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2009 Red Hat, Inc. 
+ * Copyright (c) 2009-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -21,6 +21,7 @@ import org.jboss.tools.jst.web.kb.ICSSContainerSupport;
 import org.jboss.tools.jst.web.kb.IIncludedContextSupport;
 import org.jboss.tools.jst.web.kb.IPageContext;
 import org.jboss.tools.jst.web.kb.IResourceBundle;
+import org.jboss.tools.jst.web.kb.PageContextFactory;
 import org.jboss.tools.jst.web.kb.PageContextFactory.CSSStyleSheetDescriptor;
 import org.jboss.tools.jst.web.kb.internal.taglib.NameSpace;
 import org.jboss.tools.jst.web.kb.taglib.INameSpace;
@@ -34,8 +35,11 @@ import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 public class JspContextImpl extends XmlContextImpl implements IPageContext, IIncludedContextSupport, ICSSContainerSupport {
 	protected List<IResourceBundle> bundles = new ArrayList<IResourceBundle>();
 
+	
 	protected List<ELContext> fIncludedContexts = new ArrayList<ELContext>();
-	protected List<CSSStyleSheetDescriptor> fCSSStyleSheetDescriptors = new ArrayList<CSSStyleSheetDescriptor>();;
+	// JBIDE-13864: the CSS StyleSheet descriptors are'n loaded at Context creation stage.
+	// The loading of CSS StyleSheet Descriptors is performed only if they are requested by CA or hyperlinking features.
+	protected List<CSSStyleSheetDescriptor> fCSSStyleSheetDescriptors;
 
 	public void addIncludedContext(ELContext includedContext) {
 		fIncludedContexts.add(includedContext);
@@ -154,6 +158,11 @@ public class JspContextImpl extends XmlContextImpl implements IPageContext, IInc
 	}
 
 	public List<CSSStyleSheetDescriptor> getCSSStyleSheetDescriptors() {
+		if (fCSSStyleSheetDescriptors == null) {
+			System.out.println("Performing lazy loading for CSSStyleSheetDescriptors");
+			fCSSStyleSheetDescriptors = new ArrayList<CSSStyleSheetDescriptor>();
+			PageContextFactory.updateContextWithCSSInfo(this);
+		}
 		List<CSSStyleSheetDescriptor> descrs = new ArrayList<CSSStyleSheetDescriptor>();
 		
 		descrs.addAll(fCSSStyleSheetDescriptors);


### PR DESCRIPTION
...riptor

The loading of CSS Stylesheet Descriptors is excluded from Page Context Creation. CSS Stylesheet Descriptors
are loaded in on-demand manner when they are requested by Content Assistant or Hyperlink features.
As such Page Contexts don't store a links to DOM Nodes reducing the memory overload and are loaded a little bit faster.

```
modified:   plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageContextFactory.java
modified:   plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JspContextImpl.java
```
