### PR TITLE
 JBIDE-13995 EL suggestions box options depends on order of methods

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/AutoELContentAssistantProposal.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/AutoELContentAssistantProposal.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2010-2012 Red Hat, Inc. 
+ * Copyright (c) 2010-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -12,6 +12,7 @@ package org.jboss.tools.jst.jsp.contentassist;
 
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.jdt.core.IJavaElement;
@@ -91,7 +92,7 @@ public class AutoELContentAssistantProposal extends
 		this.fJavaElements = null;
 		this.fProperySource = propertySource;
 	}
-
+	
 	/*
 	 * (non-Javadoc)
 	 * 
@@ -102,6 +103,7 @@ public class AutoELContentAssistantProposal extends
 	public String getAdditionalProposalInfo() {
 		if (fAdditionalProposalInfo == null) {
 			if (this.fJavaElements != null && this.fJavaElements.length > 0) {
+				Arrays.sort(fJavaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
 				this.fAdditionalProposalInfo = extractProposalContextInfo(fJavaElements);
 			} else if (fProperySource != null) {
 				this.fAdditionalProposalInfo = extractProposalContextInfo(fProperySource);
@@ -109,6 +111,7 @@ public class AutoELContentAssistantProposal extends
 		}
 		return fAdditionalProposalInfo;
 	}
+
 
 	/*
 	 * Extracts the additional proposal information based on Javadoc for the

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspELCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspELCompletionProposalComputer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2011 Red Hat, Inc.
+ * Copyright (c) 2010-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -10,25 +10,10 @@
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.contentassist.computers;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Region;
-import org.jboss.tools.common.el.core.model.ELExpression;
-import org.jboss.tools.common.el.core.parser.ELParserFactory;
-import org.jboss.tools.common.el.core.parser.ELParserUtil;
-import org.jboss.tools.common.el.core.resolver.ELCompletionEngine;
 import org.jboss.tools.common.el.core.resolver.ELContext;
-import org.jboss.tools.common.el.core.resolver.ELContextImpl;
-import org.jboss.tools.common.el.core.resolver.ELResolution;
-import org.jboss.tools.common.el.core.resolver.ELResolutionImpl;
-import org.jboss.tools.common.el.core.resolver.ElVarSearcher;
-import org.jboss.tools.common.el.core.resolver.IRelevanceCheck;
-import org.jboss.tools.common.el.core.resolver.Var;
 import org.jboss.tools.common.text.TextProposal;
 import org.jboss.tools.jst.web.kb.IPageContext;
 import org.jboss.tools.jst.web.kb.PageContextFactory;
@@ -37,7 +22,7 @@ import org.jboss.tools.jst.web.kb.taglib.INameSpace;
 /**
  * EL Proposal computer for JSP pages
  * 
- * @author Jeremy
+ * @author Victor Rubezhny
  *
  */
 public class JspELCompletionProposalComputer extends XmlELCompletionProposalComputer {
@@ -85,52 +70,6 @@ public class JspELCompletionProposalComputer extends XmlELCompletionProposalComp
 			}
 		}
 		return null;
-	}
-
-	protected void setVars(ELContextImpl context, IFile file) {
-		ELCompletionEngine fakeEngine = new ELCompletionEngine() {
-
-			@Override
-			public ELResolution resolveELOperand(IFile file, ELContext context,
-					ELExpression operand, boolean returnEqualedVariablesOnly,
-					List<Var> vars, ElVarSearcher varSearcher, int offset)
-					throws BadLocationException, StringIndexOutOfBoundsException {
-				return new ELResolutionImpl(operand);
-			}
-
-			@Override
-			public ELParserFactory getParserFactory() {
-				return ELParserUtil.getJbossFactory();
-			}
-
-			@Override
-			public List<TextProposal> getProposals(ELContext context, String el, int offset) {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public ELResolution resolve(ELContext context, ELExpression operand, int offset) {
-				return new ELResolutionImpl(operand);
-			}
-
-			@Override
-			public List<TextProposal> getProposals(ELContext context, int offset) {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public IRelevanceCheck createRelevanceCheck(IJavaElement element) {
-				return null;
-			}
-		};
-		ElVarSearcher varSearcher = new ElVarSearcher(file, fakeEngine);
-		List<Var> vars = varSearcher.findAllVars(file, getOffset());
-
-		if (vars != null) {
-			for (Var var : vars) {
-				context.addVar(new Region(getOffset(), 0), var);
-			}
-		}
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspTagCompletionProposalComputer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2010-2011 Red Hat, Inc.
+ * Copyright (c) 2010-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
@@ -10,28 +10,12 @@
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.contentassist.computers;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
-import org.eclipse.core.resources.IFile;
-import org.eclipse.jdt.core.IJavaElement;
-import org.eclipse.jface.text.BadLocationException;
-import org.eclipse.jface.text.Region;
 import org.eclipse.wst.sse.ui.contentassist.CompletionProposalInvocationContext;
 import org.eclipse.wst.xml.ui.internal.contentassist.ContentAssistRequest;
-import org.jboss.tools.common.el.core.model.ELExpression;
-import org.jboss.tools.common.el.core.parser.ELParserFactory;
-import org.jboss.tools.common.el.core.parser.ELParserUtil;
-import org.jboss.tools.common.el.core.resolver.ELCompletionEngine;
 import org.jboss.tools.common.el.core.resolver.ELContext;
-import org.jboss.tools.common.el.core.resolver.ELContextImpl;
-import org.jboss.tools.common.el.core.resolver.ELResolution;
-import org.jboss.tools.common.el.core.resolver.ELResolutionImpl;
-import org.jboss.tools.common.el.core.resolver.ElVarSearcher;
-import org.jboss.tools.common.el.core.resolver.IRelevanceCheck;
-import org.jboss.tools.common.el.core.resolver.Var;
-import org.jboss.tools.common.text.TextProposal;
 import org.jboss.tools.jst.web.kb.IPageContext;
 import org.jboss.tools.jst.web.kb.PageContextFactory;
 import org.jboss.tools.jst.web.kb.taglib.INameSpace;
@@ -119,51 +103,5 @@ public class JspTagCompletionProposalComputer extends XmlTagCompletionProposalCo
 	protected void addTextELProposals(ContentAssistRequest contentAssistRequest,
 			CompletionProposalInvocationContext context) {
 		// No EL proposals are to be added here
-	}
-
-	protected void setVars(ELContextImpl context, IFile file) {
-		ELCompletionEngine fakeEngine = new ELCompletionEngine() {
-
-			@Override
-			public ELResolution resolveELOperand(IFile file, ELContext context,
-					ELExpression operand, boolean returnEqualedVariablesOnly,
-					List<Var> vars, ElVarSearcher varSearcher, int offset)
-					throws BadLocationException, StringIndexOutOfBoundsException {
-				return new ELResolutionImpl(operand);
-			}
-
-			@Override
-			public ELParserFactory getParserFactory() {
-				return ELParserUtil.getJbossFactory();
-			}
-
-			@Override
-			public List<TextProposal> getProposals(ELContext context, String el, int offset) {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public ELResolution resolve(ELContext context, ELExpression operand, int offset) {
-				return new ELResolutionImpl(operand);
-			}
-
-			@Override
-			public List<TextProposal> getProposals(ELContext context, int offset) {
-				return Collections.emptyList();
-			}
-
-			@Override
-			public IRelevanceCheck createRelevanceCheck(IJavaElement element) {
-				return null;
-			}
-		};
-		ElVarSearcher varSearcher = new ElVarSearcher(file, fakeEngine);
-		List<Var> vars = varSearcher.findAllVars(file, getOffset());
-
-		if (vars != null) {
-			for (Var var : vars) {
-				context.addVar(new Region(getOffset(), 0), var);
-			}
-		}
 	}
 }

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/FaceletTagInfoHoverProcessor.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/FaceletTagInfoHoverProcessor.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2010-2012 Red Hat, Inc. 
+ * Copyright (c) 2010-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -13,6 +13,7 @@ package org.jboss.tools.jst.jsp.jspeditor.info;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringReader;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -213,6 +214,7 @@ public class FaceletTagInfoHoverProcessor extends XMLTagInfoHoverProcessor {
 				if (javaElements == null || javaElements.length == 0)
 					continue;
 				
+				Arrays.sort(javaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
 				ELInfoHoverBrowserInformationControlInput hover = JavaStringELInfoHover.getHoverInfo2Internal(javaElements, false);
 				return (hover == null ? null : hover.getHtml());
 			} else if (segment instanceof MessagePropertyELSegmentImpl) {

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2010-2011 Red Hat, Inc. 
+ * Copyright (c) 2010-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -16,6 +16,7 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StringReader;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.List;
 
 import org.eclipse.core.resources.IFile;
@@ -273,6 +274,7 @@ public class JavaStringELInfoHover extends JavadocHover {
 				if (javaElements == null || javaElements.length == 0)
 					continue;
 				
+				Arrays.sort(javaElements, ELProposalProcessor.CASE_INSENSITIVE_ORDER);
 				return JavaStringELInfoHover.getHoverInfo2Internal(javaElements, true);
 			} else if (segment instanceof MessagePropertyELSegmentImpl) {
 				MessagePropertyELSegmentImpl mpSegment = (MessagePropertyELSegmentImpl)segment;


### PR DESCRIPTION
The issue is fixed by the sorting of getters and setters and using an argument type as a property type in case
of setter is set as a first or the only one IJavaElement for the property.
The getters and setters are set to appear sorted in Content Assistatn additional info window as well as in EL Tooltips for
Java/HTML/JSP/XHTML Editors.
JUnit Test is added for the issue: org.jboss.tools.jsf.jsp.ca.test.CAELBeanPropertyTest.
Existing org.jboss.tools.jsf.jsp.hover.ELTooltipTest JUnit Test is updated as well due to test the issue.

```
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/AutoELContentAssistantProposal.java
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspELCompletionProposalComputer.java
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/JspTagCompletionProposalComputer.java
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/FaceletTagInfoHoverProcessor.java
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/info/JavaStringELInfoHover.java
```
