### PR TITLE
JBIDE-14101 The class is not compatible with JDK 1.6: org.jboss.tools.js...

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/HTMLWizardVisualPreviewInitializationException.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/HTMLWizardVisualPreviewInitializationException.java
@@ -42,16 +42,4 @@ public class HTMLWizardVisualPreviewInitializationException extends Exception {
 			Throwable cause) {
 		super(message, cause);
 	}
-
-	/**
-	 * @param message
-	 * @param cause
-	 * @param enableSuppression
-	 * @param writableStackTrace
-	 */
-	public HTMLWizardVisualPreviewInitializationException(String message,
-			Throwable cause, boolean enableSuppression,
-			boolean writableStackTrace) {
-		super(message, cause, enableSuppression, writableStackTrace);
-	}
 }


### PR DESCRIPTION
...t.web.ui.palette.html.wizard.HTMLWizardVisualPreviewInitializationException

Because I cannot find any use of that java-1.7-like constructor I just removed it from HTMLWizardVisualPreviewInitializationException class.

```
modified:   plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/HTMLWizardVisualPreviewInitializationException.java
```
