### PR TITLE
JBIDE-14311 org.jboss.tools.jst.jsp.outline.JSPPropertySourceAdapter.get...

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/outline/JSPPropertySourceAdapter.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/outline/JSPPropertySourceAdapter.java
@@ -658,7 +658,9 @@ public class JSPPropertySourceAdapter implements INodeAdapter, IPropertySource, 
 	}
 	
 	private Map<String, IAttribute> getAttributes() {
-		return PageProcessor.getInstance().getAttributesAsMap(kbQuery, pageContext);
+		return (kbQuery == null ? 
+				new HashMap<String, IAttribute>() : 
+					PageProcessor.getInstance().getAttributesAsMap(kbQuery, pageContext));
 	}
 	
 	//////// XMLPropertyDescriptor


### PR DESCRIPTION
...Attributes() invokes PageProcessor.getAttributesAsMap with query == null as an argument

Issue is fixed

```
modified:   plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/outline/JSPPropertySourceAdapter.java
```
