### PR TITLE
JBIDE-14326 Escape HTML in user input in wizards

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractNewHTMLWidgetWizard.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractNewHTMLWidgetWizard.java
@@ -286,7 +286,7 @@ public class AbstractNewHTMLWidgetWizard extends Wizard implements PropertyChang
 
 		public ElementNode(String name, String text) {
 			this.name = name;
-			this.text = text;
+			this.text = (text == null) ? null : escapeHtml(text, false);
 			this.empty = text == null;
 		}
 
@@ -352,7 +352,7 @@ public class AbstractNewHTMLWidgetWizard extends Wizard implements PropertyChang
 		String value;
 		public AttributeNode(String name, String value) {
 			this.name = name;
-			this.value = value;
+			this.value = escapeHtml(value, true);
 		}
 
 		public void flush(NodeWriter sb) {
@@ -360,5 +360,35 @@ public class AbstractNewHTMLWidgetWizard extends Wizard implements PropertyChang
 		}
 	}
 
+	public static String escapeHtml(String text, boolean isAttribute) {
+		StringBuilder sb = new StringBuilder();
+		for (int i = 0; i < text.length(); i++) {
+			char ch = text.charAt(i);
+			if(ch == '<') {
+				sb.append("&lt;");
+			} else if(ch == '>') {
+				sb.append("&gt;");
+			} else if(ch == '&' && !isEscapedSequence(text, i)) {
+				sb.append("&amp;");
+			} else if(isAttribute && ch == '"') {
+				sb.append("&quot;");
+			} else {
+				sb.append(ch);
+			}
+		}
+		return sb.toString();
+	}
+
+	static boolean isEscapedSequence(String text, int p) {
+		if(text.charAt(p) != '&') {
+			return false;
+		}
+		for (int i = p + 1; i < text.length(); i++) {
+			char ch = text.charAt(i);
+			if(ch == '&') return false;
+			if(ch == ';') return true;
+		}
+		return false;
+	}
 }
 

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/NewJQueryMobilePaletteWizardTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/NewJQueryMobilePaletteWizardTest.java
@@ -110,11 +110,24 @@ public class NewJQueryMobilePaletteWizardTest extends AbstractPaletteEntryTest i
 		assertAttrExists(wizard, ATTR_DATA_ROLE, ROLE_FOOTER);
 		assertTextExists(wizard, wizardPage.getEditorValue(EDITOR_ID_FOOTER_TITLE));
 
+		//Check " < > in attribute value.
+		assertTextDoesNotExist(wizard, ATTR_DATA_THEME);
+		wizardPage.setEditorValue(EDITOR_ID_THEME, "\"</div>");
+		assertAttrExists(wizard, ATTR_DATA_THEME, "&quot;&lt;/div&gt;");
+		wizardPage.setEditorValue(EDITOR_ID_THEME, "");
+		assertTextDoesNotExist(wizard, ATTR_DATA_THEME);
+
+		//Check < > in text.
+		String headerText = "<page title>";
+		String headerHtmlText = "&lt;page title&gt;";
+
+		wizardPage.setEditorValue(EDITOR_ID_HEADER_TITLE, headerText);
+
 		wizard.performFinish();
 
-		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
-		assertTrue(text.indexOf(ROLE_CONTENT) > 0);
-		assertTrue(text.indexOf(ROLE_PAGE) > 0);
+		assertTextIsInserted(ROLE_CONTENT);
+		assertTextIsInserted(ROLE_PAGE);
+		assertTextIsInserted(headerHtmlText);
 	}
 
 	public void testNewCheckboxWizard() {
@@ -139,8 +152,7 @@ public class NewJQueryMobilePaletteWizardTest extends AbstractPaletteEntryTest i
 
 		wizard.performFinish();
 
-		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
-		assertTrue(text.indexOf(label) > 0);
+		assertTextIsInserted(label);
 	}
 
 	public void testNewToggleWizard() {


### PR DESCRIPTION
Symbols <, >, & and " (the last for attributes only)
in user input are replaced by &lt; etc. in generated html.
Test is added.
