### PR TITLE
JBIDE-14676 Preview does not work on Mac OS

### DIFF
--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/NewJQueryMobilePaletteWizardTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/NewJQueryMobilePaletteWizardTest.java
@@ -10,10 +10,13 @@
  ******************************************************************************/ 
 package org.jboss.tools.jst.web.ui.test;
 
+import java.io.File;
+
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.ui.IEditorPart;
 import org.jboss.tools.common.ui.widget.editor.CompositeEditor;
 import org.jboss.tools.common.ui.widget.editor.IFieldEditor;
+import org.jboss.tools.jst.web.WebModelPlugin;
 import org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.JQueryConstants;
 import org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizard;
 import org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizardPage;
@@ -90,6 +93,12 @@ public class NewJQueryMobilePaletteWizardTest extends AbstractPaletteEntryTest i
 			editor = null;
 		}
 		super.tearDown();
+	}
+
+	public void testScriptsAreCopied() {
+		File f = WebModelPlugin.getJSStateRoot();
+		assertTrue(new File(f, "js").isDirectory());
+		assertTrue(new File(f, "js/jquery.mobile.structure-1.2.0.min.css").isFile());
 	}
 
 	public void testNewPageWizard() {


### PR DESCRIPTION
Preview in jQuery Mobile Palette wizards does not work on Mac OS.
Copied js and css resources to plugin state location.
Referenced them with protocol 'file:' instead 'jar:'.
