### PR TITLE
 JBIDE-14735 Improve text formatting when dropping widgets from Palette ...

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/contentassist/computers/XmlTagCompletionProposalComputer.java
@@ -743,7 +743,7 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 			Properties properties = new Properties();
 			
 			properties.put(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, "true"); //$NON-NLS-1$
-			properties.put(PaletteInsertHelper.PROPOPERTY_START_TEXT, ""); //$NON-NLS-1$
+			properties.put(PaletteInsertHelper.PROPERTY_START_TEXT, ""); //$NON-NLS-1$
 			properties.put(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI, uri);
 			properties.put(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX, prefix);
 			properties.put(JSPPaletteInsertHelper.PROPOPERTY_FORCE_PREFIX, "true");

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/i18n/ExternalizeStringsUtils.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/i18n/ExternalizeStringsUtils.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007-2010 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/
 package org.jboss.tools.jst.jsp.i18n;
 
@@ -682,8 +682,8 @@ public class ExternalizeStringsUtils {
 							p.setProperty(URIConstants.LIBRARY_VERSION, ""); //$NON-NLS-1$
 							p.setProperty(URIConstants.DEFAULT_PREFIX, jsfCoreTaglibPrefix);
 							p.setProperty(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, "true"); //$NON-NLS-1$
-							p.setProperty(JSPPaletteInsertHelper.PROPOPERTY_REFORMAT_BODY, "yes"); //$NON-NLS-1$
-							p.setProperty(PaletteInsertHelper.PROPOPERTY_START_TEXT, 
+							p.setProperty(JSPPaletteInsertHelper.PROPERTY_REFORMAT_BODY, "yes"); //$NON-NLS-1$
+							p.setProperty(PaletteInsertHelper.PROPERTY_START_TEXT, 
 									"<%@ taglib uri=\"http://java.sun.com/jsf/core\" prefix=\"f\" %>\\n"); //$NON-NLS-1$
 							PaletteTaglibInserter.inserTaglib(ed.getTextViewer().getDocument(), p);
 						}

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/FileDropCommand.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/FileDropCommand.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.jspeditor.dnd;
 
@@ -52,15 +52,15 @@ public class FileDropCommand extends DefaultDropCommand {
 		}
 
 		Properties properties = new Properties();
-		properties.put(PaletteInsertHelper.PROPOPERTY_TAG_NAME,getDefaultModel().getTagProposal().getName());
-		properties.put(PaletteInsertHelper.PROPOPERTY_START_TEXT, generateStartText());
-		properties.put(PaletteInsertHelper.PROPOPERTY_END_TEXT, generateEndText());
-		properties.put(PaletteInsertHelper.PROPOPERTY_REFORMAT_BODY, getReformatBodyProperty());
+		properties.put(PaletteInsertHelper.PROPERTY_TAG_NAME,getDefaultModel().getTagProposal().getName());
+		properties.put(PaletteInsertHelper.PROPERTY_START_TEXT, generateStartText());
+		properties.put(PaletteInsertHelper.PROPERTY_END_TEXT, generateEndText());
+		properties.put(PaletteInsertHelper.PROPERTY_REFORMAT_BODY, getReformatBodyProperty());
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI, uri);
 		String version = ((TagProposal)getDefaultModel().getTagProposal()).getLibraryVersion();
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_VERSION, version);
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX,getDefaultModel().getTagProposal().getPrefix());
-		properties.put(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER, getDefaultModel().getDropData().getSelectionProvider());
+		properties.put(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER, getDefaultModel().getDropData().getSelectionProvider());
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, "true"); //$NON-NLS-1$
 		fillPropertiesForRun(properties);
 		addCustomProperties(properties);

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/JSPPaletteInsertHelper.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/JSPPaletteInsertHelper.java
@@ -1,3 +1,13 @@
+/*******************************************************************************
+ * Copyright (c) 2007-2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
 package org.jboss.tools.jst.jsp.jspeditor.dnd;
 
 import java.util.Properties;
@@ -34,7 +44,7 @@ public class JSPPaletteInsertHelper extends PaletteInsertHelper {
 	protected void modify(ISourceViewer v, Properties p, String[] texts) {
 		if(!MobilePaletteInsertHelper.getInstance().isMobile(v, p, texts)){
 			p.put("viewer", v);
-			String tagname = p.getProperty(PROPOPERTY_TAG_NAME);
+			String tagname = p.getProperty(PROPERTY_TAG_NAME);
 			String uri = p.getProperty(PROPOPERTY_TAGLIBRARY_URI);
 			String startText = texts[0];
 			if(startText != null && startText.startsWith("<%@ taglib")) { //$NON-NLS-1$

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/MobilePaletteInsertHelper.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/MobilePaletteInsertHelper.java
@@ -178,7 +178,7 @@ public class MobilePaletteInsertHelper extends PaletteInsertHelper {
 				if(globalPosition == -1){
 					globalPosition = relatedNode.getStartStructuredDocumentRegion().getStartOffset()-1;
 					goobalLength = 0;
-					newLineBefore = false;
+					newLineBefore = true;
 					newLineAfter = true;
 				}
 			}

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteDropCommand.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteDropCommand.java
@@ -1,12 +1,12 @@
 /*******************************************************************************
- * Copyright (c) 2007 Exadel, Inc. and Red Hat, Inc.
+ * Copyright (c) 2007-2013 Red Hat, Inc.
  * Distributed under license by Red Hat, Inc. All rights reserved.
  * This program is made available under the terms of the
  * Eclipse Public License v1.0 which accompanies this distribution,
  * and is available at http://www.eclipse.org/legal/epl-v10.html
  *
  * Contributors:
- *     Exadel, Inc. and Red Hat, Inc. - initial API and implementation
+ *     Red Hat, Inc. - initial API and implementation
  ******************************************************************************/ 
 package org.jboss.tools.jst.jsp.jspeditor.dnd;
 
@@ -67,9 +67,9 @@ public class PaletteDropCommand extends FileDropCommand {
 	}
 
 	protected void addCustomProperties(Properties runningProperties) {		
-		newLine = properties.getProperty(PaletteInsertHelper.PROPOPERTY_NEW_LINE);
+		newLine = properties.getProperty(PaletteInsertHelper.PROPERTY_NEW_LINE);
 		if (newLine == null) newLine="true"; //$NON-NLS-1$
-		runningProperties.setProperty(PaletteInsertHelper.PROPOPERTY_NEW_LINE, newLine);
+		runningProperties.setProperty(PaletteInsertHelper.PROPERTY_NEW_LINE, newLine);
 		String addTaglib = properties.getProperty(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB);
 		if(addTaglib == null) addTaglib = "true"; //$NON-NLS-1$
 		runningProperties.setProperty(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, addTaglib);
@@ -80,10 +80,10 @@ public class PaletteDropCommand extends FileDropCommand {
 			if(startText == null && endText == null) return;
 			int pos = ((ITextSelection)getDefaultModel().getDropData().getSelectionProvider().getSelection()).getOffset();
 			getDefaultModel().getDropData().getSourceViewer().setSelectedRange(pos, 0);
-			if(startText != null) properties.setProperty(PaletteInsertHelper.PROPOPERTY_START_TEXT, startText);
-			if(endText != null) properties.setProperty(PaletteInsertHelper.PROPOPERTY_END_TEXT, endText);
-			if(reformat != null) properties.setProperty(PaletteInsertHelper.PROPOPERTY_REFORMAT_BODY, reformat);
-			if(newLine != null) properties.setProperty(PaletteInsertHelper.PROPOPERTY_NEW_LINE, newLine);
+			if(startText != null) properties.setProperty(PaletteInsertHelper.PROPERTY_START_TEXT, startText);
+			if(endText != null) properties.setProperty(PaletteInsertHelper.PROPERTY_END_TEXT, endText);
+			if(reformat != null) properties.setProperty(PaletteInsertHelper.PROPERTY_REFORMAT_BODY, reformat);
+			if(newLine != null) properties.setProperty(PaletteInsertHelper.PROPERTY_NEW_LINE, newLine);
 			JSPPaletteInsertHelper.getInstance().insertIntoEditor(
 					getDefaultModel().getDropData().getSourceViewer(),
 					properties

--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/dnd/PaletteTaglibInserter.java
@@ -65,7 +65,7 @@ public class PaletteTaglibInserter {
 				!p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI).equals(JSP_URI) &&
 				p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX) != null &&
 				p.getProperty(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX).length() > 0 &&
-				p.getProperty(PaletteInsertHelper.PROPOPERTY_START_TEXT) != null;
+				p.getProperty(PaletteInsertHelper.PROPERTY_START_TEXT) != null;
 	}
 
 	public boolean inserTaglibInOldJsp(IDocument d, Properties p) {
@@ -155,7 +155,7 @@ public class PaletteTaglibInserter {
 	}
 	
 	private static Node getSelectedNode(IDocument d, Properties p){
-		ISelectionProvider selProvider = (ISelectionProvider)p.get(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER);
+		ISelectionProvider selProvider = (ISelectionProvider)p.get(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER);
 		if(selProvider == null) return null;
 		
 		ITextSelection selection = null;
@@ -361,7 +361,7 @@ public class PaletteTaglibInserter {
 
 	private static void mouveFocusOnPage(Properties p, int length, int pos){
 		ISourceViewer v = getViewer(p);
-		ISelectionProvider selProvider = (ISelectionProvider)p.get(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER);
+		ISelectionProvider selProvider = (ISelectionProvider)p.get(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER);
 		IDocument doc = v.getDocument();
 
 		if (doc== null || selProvider == null) return;
@@ -369,12 +369,12 @@ public class PaletteTaglibInserter {
 		ITextSelection selection = (ITextSelection)selProvider.getSelection();
 		if (selection.getOffset() == 0) {			
 			 v.setSelectedRange(length,0);
-			 p.put(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER,v.getSelectionProvider());
+			 p.put(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER,v.getSelectionProvider());
 		}
 		else 
 		if (selection.getOffset() == pos ){
 			v.setSelectedRange(length, 0);
-			p.put(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER,v.getSelectionProvider());
+			p.put(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER,v.getSelectionProvider());
 		}
 	}
 

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/action/AddTLDMarkerResolution.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/action/AddTLDMarkerResolution.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2010 Red Hat, Inc. 
+ * Copyright (c) 2010-2013 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -62,11 +62,11 @@ public class AddTLDMarkerResolution implements IQuickFix{
 	private Properties getProperties(){
 		Properties properties = new Properties();
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_ADD_TAGLIB, "true"); //$NON-NLS-1$
-		properties.put(PaletteInsertHelper.PROPOPERTY_START_TEXT, ""); //$NON-NLS-1$
+		properties.put(PaletteInsertHelper.PROPERTY_START_TEXT, ""); //$NON-NLS-1$
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_TAGLIBRARY_URI, uri);
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_DEFAULT_PREFIX, prefix);
 		properties.put(JSPPaletteInsertHelper.PROPOPERTY_FORCE_PREFIX, "true");
-		properties.put(PaletteInsertHelper.PROPOPERTY_SELECTION_PROVIDER, new ISelectionProvider() {
+		properties.put(PaletteInsertHelper.PROPERTY_SELECTION_PROVIDER, new ISelectionProvider() {
 			
 			@Override
 			public void setSelection(ISelection selection) {

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/InsertJSCSSPaletteEntryTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/InsertJSCSSPaletteEntryTest.java
@@ -1,7 +1,5 @@
 package org.jboss.tools.jst.web.ui.test;
 
-import java.util.StringTokenizer;
-
 import org.eclipse.jface.wizard.IWizardPage;
 import org.eclipse.jface.wizard.WizardDialog;
 import org.eclipse.ui.IEditorPart;
@@ -36,6 +34,28 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 			CSS_LINK,
 			MobilePaletteInsertHelper.JQUERY_SCRIPT + ">",
 			MobilePaletteInsertHelper.JQUERY_MOBILE_SCRIPT + ">",
+			"",
+			"</head>",
+			"<body>",
+			"<div data-role=\"collapsible-set\">",
+			"<div data-role=\"collapsible\">",
+			"<h3>I'm a header</h3>",
+			"<p>I'm the collapsible content.</p>",
+			"",
+			"</div>",
+		    "</div>",
+		    "</body>",
+		    "",
+			"</html>"
+	};
+	private String[] test_result_2_1={
+			"<!DOCTYPE html>",
+			"<html>",
+		    "<head>",
+			"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
+			CSS_LINK,
+			MobilePaletteInsertHelper.JQUERY_SCRIPT + ">",
+			MobilePaletteInsertHelper.JQUERY_MOBILE_SCRIPT + ">",
 			"</head>",
 			"<body>",
 			"<div data-role=\"collapsible-set\">",
@@ -56,6 +76,7 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 			CSS_LINK,
 			MobilePaletteInsertHelper.JQUERY_SCRIPT + ">",
 			MobilePaletteInsertHelper.JQUERY_MOBILE_SCRIPT + ">",
+			"",
 			"</head>",
 			"<body>",
 			"</body>",
@@ -97,7 +118,7 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 		editor = openEditor("insert_around.html");
 		runToolEntry("jQuery Mobile", "JS/CSS", false);
 		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
-		compare(text, test_result_2);
+		compare(text, test_result_2_1);
 	}
 	
 	public void testInsertIntoNotClosedTags(){
@@ -111,7 +132,7 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 		editor = openEditor("normal.html");
 		runToolEntry("jQuery Mobile", "JS/CSS", false);
 		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
-		compare(text, test_result_2);
+		compare(text, test_result_2_1);
 	}
 	
 	public void testInsertIntoDifferentVersion(){
@@ -177,10 +198,10 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 	}
 
 	private void compare(String test, String[] result){
-		StringTokenizer tokenizer = new StringTokenizer(test, "\n");
-		assertEquals("Unexpected number of lines",result.length, tokenizer.countTokens());
+		String[] spl = test.split("\n");
+		assertEquals("Unexpected number of lines",result.length, spl.length);
 		for(int i = 0; i < result.length; i++){
-			String token = tokenizer.nextToken().trim();
+			String token = spl[i].trim();
 			assertEquals("Unexpected line", result[i], token);
 		}
 	}


### PR DESCRIPTION
...view

Issue is fixed. Prev. sibling/parent tag is used to calculate the indent of the template text
that is to be inserted. 'Use spaces' option is taken into account. All indents that are inserted are
recalculated by using tabs (until it's possible) then spaces.
JUnit Test is added for the issue: org.jboss.tools.common.model.ui.views.palette.test.PaletteInsertHelperTest
Typoo in constant names are fixed
