### PR TITLE
JBIDE-15017 CSS Editor dialog and CSS preview do not work on Windows 64

### DIFF
--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/browser/CSSBrowser.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/browser/CSSBrowser.java
@@ -48,7 +48,7 @@ public class CSSBrowser extends Composite implements CSSBrowserInterface {
 		cssBrowser.setLayout(new GridLayout());
 		Browser browser=null;
 		try {
-			browser = new Browser(cssBrowser, SWT.BORDER | SWT.MOZILLA);
+			browser = new Browser(cssBrowser, SWT.NONE);
 			GridData gridData = new GridData();
 			gridData.horizontalAlignment = SWT.FILL;
 			gridData.verticalAlignment = SWT.FILL;
@@ -56,15 +56,16 @@ public class CSSBrowser extends Composite implements CSSBrowserInterface {
 			gridData.grabExcessVerticalSpace = true;
 			browser.setLayoutData(gridData);
 			browser.pack();
-		} catch(SWTError er){
-			CSSPlugin.getDefault().logWarning("Xulrunner implementation hasn't been founded, so browser based preview " +
-					"will be not available");
+		} catch(SWTError e){
+			CSSPlugin.getDefault().logWarning("Cannot create Browser. Browser-based preview " +
+					"will not be available.", e);
 		}
 		if(browser!=null) {
-			cssBrowser.setBrowser(new CSSBrowserMozillaImplementation(browser));
+			cssBrowser.setBrowser(new CSSBrowserImplementation(browser));
 		} else {
 			Label label = new Label(cssBrowser,SWT.CENTER);
-			label.setText("Browser based preview not availabe,"+System.getProperty("line.separator")+" see log for more details");
+			label.setText("Browser based preview not availabe,\n"
+					+ "see log for more details");
 			label.setBounds(cssBrowser.getClientArea());
 			cssBrowser.setBrowser(new CSSBrowserEmptyImplementation());
 		}

--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/browser/CSSBrowserImplementation.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/browser/CSSBrowserImplementation.java
@@ -18,31 +18,26 @@ import org.eclipse.swt.events.TypedEvent;
  * @author mareshkau
  *
  */
-class CSSBrowserMozillaImplementation implements CSSBrowserInterface {
+class CSSBrowserImplementation implements CSSBrowserInterface {
 	final private Browser browser;
 
-	public CSSBrowserMozillaImplementation(Browser browser) {
+	public CSSBrowserImplementation(Browser browser) {
 		super();
 		this.browser = browser;
 	}
 	public boolean setFocus() {
-		return getBrowser().setFocus();
+		return browser.setFocus();
 	}
 	public void setText(String generateBrowserPage) {
-		getBrowser().setText(generateBrowserPage);
+		browser.setText(generateBrowserPage);
 	}
 	public void setEnabled(boolean isEnabled) {
-		getBrowser().setEnabled(isEnabled);
+		browser.setEnabled(isEnabled);
 	}
 	public void addMouseListener(MouseAdapter mouseAdapter) {
-		getBrowser().addMouseListener(mouseAdapter);
+		browser.addMouseListener(mouseAdapter);
 	}
 	public boolean isBrowserEvent(TypedEvent e){
-		return e.widget==getBrowser();
+		return e.widget == browser;
 	}
-	
-	private Browser getBrowser() {
-		return this.browser;
-	}
-	
 }

--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/AbstractCSSDialog.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/dialog/AbstractCSSDialog.java
@@ -38,6 +38,7 @@ import org.jboss.tools.common.model.ui.ModelUIImages;
 import org.jboss.tools.common.model.ui.widgets.Split;
 import org.jboss.tools.jst.css.browser.CSSBrowser;
 import org.jboss.tools.jst.css.dialog.common.StyleAttributes;
+import org.jboss.tools.jst.css.view.CSSPreviewPageCreator;
 import org.jboss.tools.jst.jsp.messages.JstUIMessages;
 import org.jboss.tools.jst.jsp.util.Constants;
 
@@ -161,7 +162,7 @@ public abstract class AbstractCSSDialog extends TitleAreaDialog {
 				true);
 		previewComposite.setLayoutData(gridData);
 
-		browser = CSSBrowser.createCSSBrowser(previewComposite, SWT.BORDER | SWT.MOZILLA);
+		browser = CSSBrowser.createCSSBrowser(previewComposite, SWT.BORDER);
 		browser.setText(generateBrowserPage());
 		browser.setLayoutData(gridData);
 		
@@ -230,23 +231,19 @@ public abstract class AbstractCSSDialog extends TitleAreaDialog {
 	}
 
 	/**
-	 * /** Method is used to build html body that is appropriate to browse.
+	 * Method is used to build html body that is appropriate to browse.
 	 * 
 	 * @return String html text representation
 	 */
 	public String generateBrowserPage() {
-		StringBuffer html = new StringBuffer("<style>span{"); //$NON-NLS-1$
+		StringBuffer style = new StringBuffer();
 
-		for (Map.Entry<String, String> styleItem : getStyleAttributes()
-				.entrySet()) {
-
-			html.append(styleItem.getKey() + Constants.COLON
+		for (Map.Entry<String, String> styleItem : getStyleAttributes().entrySet()) {
+			style.append(styleItem.getKey() + Constants.COLON
 					+ styleItem.getValue() + Constants.SEMICOLON);
 		}
 
-		html.append("}</style><span>" + getPreviewContent() + "</span>"); //$NON-NLS-1$ //$NON-NLS-2$
-
-		return html.toString();
+		return CSSPreviewPageCreator.createPreviewHtml(style.toString(), getPreviewContent());
 	}
 	
 	public void releaseResources() {

--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/view/CSSPreview.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/view/CSSPreview.java
@@ -80,7 +80,7 @@ public class CSSPreview extends ViewPart implements ICSSViewListner {
 		GridData gridData = new GridData(GridData.FILL, GridData.FILL, true, true);
 		previewComposite.setLayoutData(gridData);
 
-		browser = CSSBrowser.createCSSBrowser(previewComposite, SWT.BORDER | SWT.MOZILLA);
+		browser = CSSBrowser.createCSSBrowser(previewComposite, SWT.BORDER);
 		browser.setLayoutData(gridData);
 		browser.addMouseListener(new MouseAdapter() {
 			public void mouseDoubleClick(MouseEvent e) {
@@ -133,8 +133,7 @@ public class CSSPreview extends ViewPart implements ICSSViewListner {
 	 * @return String html text representation
 	 */
 	public String generateBrowserPage() {
-		return Constants.OPEN_DIV_TAG + getCurrentStyle()
-				+ "\">" + getPreviewContent() + Constants.CLOSE_DIV_TAG; //$NON-NLS-1$
+		return CSSPreviewPageCreator.createPreviewHtml(getCurrentStyle(), getPreviewContent());
 	}
 
 	public String getPreviewContent() {

--- a/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/view/CSSPreviewPageCreator.java
+++ b/plugins/org.jboss.tools.jst.css/src/org/jboss/tools/jst/css/view/CSSPreviewPageCreator.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2007-2013 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.css.view;
+
+/**
+ * @author Yahor Radtsevich (yradtsevich)
+ */
+public class CSSPreviewPageCreator {
+	/**
+	 * Generates preview HTML page for given CSS {@code style}
+	 * and text {@code content}
+	 */
+	@SuppressWarnings("nls")
+	public static String createPreviewHtml(String style, String content) {
+		return
+			"<html>"
+			+    "<head>"
+			+        "<style>"
+			+            "div {"
+			+                style
+			+            "}"
+			+         "</style>"
+			+     "</head>"
+			+     "<body style='margin:0; padding:0px;'>"
+			+         "<div>" 
+			+             content
+			+         "</div>"
+			+      "</body>"
+			+ "</html>"; 
+	}
+}


### PR DESCRIPTION
- Moved to SWT.NONE instead of SWT.MOZILLA
- Wrapped <div> by <body> in preview. So the text can be at least alligned horizontally now
