### PR TITLE
JBIDE-15257 JBT JSP Editor is slowed by JSPTextEditor.handleCursorPositionChanged

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/JSPTextEditor.java
+++ b/plugins/org.jboss.tools.jst.jsp/src/org/jboss/tools/jst/jsp/jspeditor/JSPTextEditor.java
@@ -1067,15 +1067,13 @@ public class JSPTextEditor extends StructuredTextEditor implements
 			storedSelection = p;
 			if (selection instanceof ITextSelection) {
 				ITextSelection ts = (ITextSelection) selection;
-//				getSelectionProvider().setSelection(ts);
 				if (ts.getLength() == 0) {
-					getSelectionProvider().setSelection(ts);
-//					if (vpeController != null) {
-//						vpeController
-//								.selectionChanged(new SelectionChangedEvent(
-//										getSelectionProvider(),
-//										getSelectionProvider().getSelection()));
-//					}
+					if (vpeController != null) {
+						vpeController
+								.selectionChanged(new SelectionChangedEvent(
+										getSelectionProvider(),
+										getSelectionProvider().getSelection()));
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Restored implementation as before changes done to JBIDE-7059.
