### PR TITLE
JBIDE-10219 Migrate org.eclipse.core.runtime.contentTypes

### DIFF
--- a/plugins/org.jboss.tools.jst.jsp/plugin.xml
+++ b/plugins/org.jboss.tools.jst.jsp/plugin.xml
@@ -593,7 +593,7 @@
    	</extension>
    
 	
-    <extension point="org.eclipse.core.runtime.contentTypes">
+    <extension point="org.eclipse.core.contenttype.contentTypes">
       	<content-type 
 	      	id="org.jboss.tools.jst.jsp.jspincludesource"
 	       	name="%ContentType_JBossToolsINC"


### PR DESCRIPTION
Migrate org.eclipse.core.runtime.contentTypes extension points to  org.eclipse.core.contenttype.contentTypes
