### PR TITLE
JBIDE-16443 Standard HTML quickfixes aren't shown in JBoss Tools HTML/JS...

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/plugin.xml
+++ b/plugins/org.jboss.tools.jst.web.ui/plugin.xml
@@ -1007,10 +1007,6 @@
 			class="org.eclipse.wst.xml.ui.internal.projection.XMLFoldingStrategy"
 			target="org.eclipse.wst.html.core.htmlsource" />
 		<provisionalConfiguration
-			type="org.eclipse.jface.text.quickassist.IQuickAssistProcessor"
-			class="org.eclipse.wst.xml.ui.internal.correction.XMLQuickAssistProcessor"
-			target="org.eclipse.wst.html.HTML_DEFAULT" />
-		<provisionalConfiguration
 			type="autoeditstrategy"
 			class="org.eclipse.wst.html.ui.internal.autoedit.StructuredAutoEditStrategyHTML"
 			target="org.eclipse.wst.html.HTML_DEFAULT, org.eclipse.wst.html.HTML_DECLARATION" />


### PR DESCRIPTION
...P editors

The duplication of WST QuickFixes is fixed

Signed-off-by: vrubezhny vrubezhny@exadel.com
