### PR TITLE
JBIDE-14597 warning about ng-* attributes used by angular js should be p...

### DIFF
--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/quickassist/JstJspQuickAssistTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/quickassist/JstJspQuickAssistTest.java
@@ -21,7 +21,6 @@ import org.eclipse.jface.text.quickassist.IQuickAssistAssistant;
 import org.eclipse.jface.text.source.ISourceViewer;
 import org.eclipse.jface.text.source.SourceViewer;
 import org.eclipse.jface.text.source.TextInvocationContext;
-import org.eclipse.swt.widgets.Display;
 import org.eclipse.ui.IEditorInput;
 import org.eclipse.ui.IEditorPart;
 import org.eclipse.ui.PlatformUI;
@@ -29,7 +28,6 @@ import org.eclipse.ui.internal.Workbench;
 import org.eclipse.ui.part.FileEditorInput;
 import org.jboss.tools.jst.web.ui.internal.editor.jspeditor.JSPMultiPageEditor;
 import org.jboss.tools.jst.web.ui.internal.editor.jspeditor.JSPTextEditor;
-import org.jboss.tools.test.util.JobUtils;
 import org.jboss.tools.test.util.ProjectImportTestSetup;
 
 public class JstJspQuickAssistTest extends TestCase {
@@ -71,22 +69,10 @@ public class JstJspQuickAssistTest extends TestCase {
 			final int offset = text.indexOf(str);
 			final int length = str.length();
 			assertTrue("String - "+str+" not found", offset > 0);
-			final Object[] result = new Object[1]; 
-			document.set(text); // To make a change in editor
-			JobUtils.waitForIdle();
-		
-			Display.getDefault().syncExec(new Runnable() {
-				@Override
-				public void run() {
-					IQuickAssistAssistant assiatant = ((SourceViewer)viewer).getQuickAssistAssistant();
-					TextInvocationContext ctx = new TextInvocationContext(viewer, offset, length);
-					ICompletionProposal[] proposals = assiatant.getQuickAssistProcessor().computeQuickAssistProposals(ctx);
-					result[0] = proposals;
-				}
-			});
-			assertNotNull(result[0]);
-			assertTrue(result[0] instanceof ICompletionProposal[]);
-			ICompletionProposal[] proposals = (ICompletionProposal[])result[0];
+
+			IQuickAssistAssistant assiatant = ((SourceViewer)viewer).getQuickAssistAssistant();
+			TextInvocationContext ctx = new TextInvocationContext(viewer, offset, length);
+			ICompletionProposal[] proposals = assiatant.getQuickAssistProcessor().computeQuickAssistProposals(ctx);
 			
 			for(ICompletionProposal proposal : proposals){
 				if (proposal.getClass().getName().equals(proposalClassName)) {

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/JstWebUiAllTests.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/JstWebUiAllTests.java
@@ -13,11 +13,7 @@ package org.jboss.tools.jst.web.ui.test;
 import junit.framework.Test;
 import junit.framework.TestSuite;
 
-import org.jboss.tools.jst.web.ui.css.test.CSSAllTests;
-import org.jboss.tools.jst.web.ui.editor.test.JstJspAllTests;
-import org.jboss.tools.jst.web.ui.openon.test.JstTextExtAllTests;
 import org.jboss.tools.test.util.ProjectImportTestSetup;
-
 
 /**
  * @author eskimo
@@ -27,12 +23,6 @@ public class JstWebUiAllTests {
 	
 	public static Test suite() {
 		TestSuite suite = new TestSuite(JstWebUiAllTests.class.getName());
-
-		suite.addTest(JstJspAllTests.suite());
-
-		suite.addTest(JstTextExtAllTests.suite());
-
-		suite.addTest(CSSAllTests.suite());
 
 		TestSuite s = new TestSuite("Palette content");
 		s.addTestSuite(JBossToolsEditorTest.class);


### PR DESCRIPTION
...ossible to ignore

JUnit test for the issue is updated.
The 'tests run twice as much' is fixed.

Signed-off-by: vrubezhny vrubezhny@exadel.com
