### PR TITLE
JBIDE-16513 NPE when defining Visual Template

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/plugin.xml
+++ b/plugins/org.jboss.tools.jst.web.ui/plugin.xml
@@ -1532,7 +1532,7 @@
      </category>
      <command
            categoryId="org.jboss.tools.jst.jsp.commands.category"
-           id="org.jboss.tools.jst.jsp.commands.showSelectionBar"
+           id="org.jboss.tools.jst.web.ui.internal.editor.commands.showSelectionBar"
            name="%Toggle.Selection.Bar">
            <state
                  class="org.eclipse.ui.handlers.RegistryToggleState:true"


### PR DESCRIPTION
Looks like you change command ID in java class but forgot to do it in plugin.xml during jst plugins refactoring.

There is also some other jst.jsp commands in plugin file. Could you chack once again if everything correct there?
