### PR TITLE
JBIDE-17004 Null Pointer Exception in FormPropertySheetViewer

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/FormPropertySheetViewer.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/FormPropertySheetViewer.java
@@ -279,7 +279,7 @@ public class FormPropertySheetViewer extends Viewer implements SelectionListener
 		int i = tab.getSelectionIndex();
 		if(i >= 0) {
 			TabItem item = tab.getItem(i);
-			if(item != null) {
+			if(item != null && item.getData() != null) {
 				String category = item.getData().toString();
 				selectedViewer = setViewersByCategory.get(category);
 			}


### PR DESCRIPTION
Check for non-null data in tab item is added, since in some OS
selectionevent goes right when item is created, before data is set.
