### PR TITLE
JBIDE-17175 org.jboss.tools.jst.web.kb.test failure on Windows

### DIFF
--- a/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/KbModelWithSeveralJarCopiesTest.java
+++ b/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/KbModelWithSeveralJarCopiesTest.java
@@ -70,7 +70,7 @@ public class KbModelWithSeveralJarCopiesTest extends TestCase {
 		Set<String> paths = new HashSet<String>();
 		
 		for (ITagLibrary l: ls) {
-			String path = l.getSourcePath().toString();
+			String path = l.getSourcePath().toOSString();
 			paths.add(path);
 			XModelObject o = (XModelObject)((KbObject)l).getId();
 			XModelObject fs = FileSystemsHelper.getLibs(o.getModel()).getLibrary(path);


### PR DESCRIPTION
Test testKbModelWithSeveralJarCopies(org.jboss.tools.jst.web.kb.test.KbModelWithSeveralJarCopiesTest)
is fixed.
