### PR TITLE
JBIDE-17171 Tab jQuery of Properties View: Cosmetic problems

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/advanced/AbstractAdvancedPropertySetViewer.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/advanced/AbstractAdvancedPropertySetViewer.java
@@ -317,13 +317,16 @@ public abstract class AbstractAdvancedPropertySetViewer extends AbstractProperty
 
 	/**
 	 * Adds editor to assigned parent composite.
+	 * Returns 1 if editor is available, otherwise returns 0.
 	 * @param editor
 	 * @param parent
 	 */
-	public void layoutEditor(String id, Composite parent) {
+	public int layoutEditor(String id, Composite parent) {
 		if(getEditor(id) != null) {
 			layoutEditor(getEditor(id), parent, true);
+			return 1;
 		}
+		return 0;
 	}
 
 	/**

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/jquery/JQueryLayouts.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/jquery/JQueryLayouts.java
@@ -116,14 +116,14 @@ public class JQueryLayouts implements JQueryHTMLConstants {
 		v.layoutEditor(ATTR_DATA_ROLE, fields);
 		v.layoutEditor(ATTR_DATA_TITLE, fields);
 		LayoutUtil.createSeparator(fields);
-		v.layoutEditor(ATTR_DATA_CORNERS, fields);
-		v.layoutEditor(ATTR_DATA_CLOSE_BTN, fields);
-		v.layoutEditor(ATTR_DATA_CLOSE_BTN_TEXT, fields);
-		LayoutUtil.createSeparator(fields);
-		v.layoutEditor(ATTR_DATA_THEME, fields);
-		v.layoutEditor(ATTR_DATA_OVERLAY_THEME, fields);
-		LayoutUtil.createSeparator(fields);
-		layoutAjaxEnhanceDom(fields, true);
+		int count = v.layoutEditor(ATTR_DATA_CORNERS, fields)
+					+ v.layoutEditor(ATTR_DATA_CLOSE_BTN, fields)
+					+ v.layoutEditor(ATTR_DATA_CLOSE_BTN_TEXT, fields);
+		if(count > 0) LayoutUtil.createSeparator(fields);
+		count = v.layoutEditor(ATTR_DATA_THEME, fields)
+				+ v.layoutEditor(ATTR_DATA_OVERLAY_THEME, fields);
+		if(count > 0) LayoutUtil.createSeparator(fields);
+		layoutAjaxEnhanceDom(fields, false);
 	}
 
 	public void layoutPage(Composite fields, List<Entry> entries) {
@@ -131,18 +131,21 @@ public class JQueryLayouts implements JQueryHTMLConstants {
 		v.layoutEditor(ATTR_DATA_TITLE, fields);
 		LayoutUtil.createSeparator(fields);
 
-		v.layoutEditor(ATTR_DATA_CLOSE_BTN_TEXT, fields);
-		v.layoutEditor(ATTR_DATA_ADD_BACK_BUTTON, fields);
-		Composite backParent = LayoutUtil.createPanel(fields);
-		v.layoutEditor(ATTR_DATA_BACK_BUTTON_TEXT, backParent);
-		v.layoutEditor(ATTR_DATA_BACK_BUTTON_THEME, backParent);
+		int count = v.layoutEditor(ATTR_DATA_CLOSE_BTN_TEXT, fields)
+					+ v.layoutEditor(ATTR_DATA_ADD_BACK_BUTTON, fields);
+		if(v.hasEditor(ATTR_DATA_BACK_BUTTON_TEXT) || v.hasEditor(ATTR_DATA_BACK_BUTTON_THEME)) {
+			Composite backParent = LayoutUtil.createPanel(fields);
+			v.layoutEditor(ATTR_DATA_BACK_BUTTON_TEXT, backParent);
+			v.layoutEditor(ATTR_DATA_BACK_BUTTON_THEME, backParent);
+			count++;
+		}
 
-		LayoutUtil.createSeparator(fields);
+		if(count > 0) LayoutUtil.createSeparator(fields);
 
-		v.layoutEditor(ATTR_DATA_THEME, fields);
-		v.layoutEditor(ATTR_DATA_OVERLAY_THEME, fields);
+		count = v.layoutEditor(ATTR_DATA_THEME, fields)
+				+ v.layoutEditor(ATTR_DATA_OVERLAY_THEME, fields);
 
-		layoutAjaxEnhanceDom(fields, true);
+		layoutAjaxEnhanceDom(fields, count > 0);
 	}
 
 	public void layoutPanel(Composite fields, List<Entry> entries) {

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/jquery/JQueryPropertySetViewer.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/properties/jquery/JQueryPropertySetViewer.java
@@ -105,7 +105,7 @@ public class JQueryPropertySetViewer extends AbstractAdvancedPropertySetViewer i
 			layouts.layoutToolbar(fields, entries);
 		} else {
 			if(hasEditor(ATTR_DATA_ROLE)) {
-				layoutEditor(getEditor(ATTR_DATA_ROLE), fields);
+				layoutEditor(getEditor(ATTR_DATA_ROLE), fields, true);
 				if(entries.size() > 1) {
 					LayoutUtil.createSeparator(fields);
 				}


### PR DESCRIPTION
1. Extra separators are removed.
2. Data Role field with default size is expanded to fill the width of the view.
