### PR TITLE
JBIDE-17406 o.j.t.jst.jsdt has no source folder pointed in build.propert...

### DIFF
--- a/plugins/org.jboss.tools.jst.jsdt/build.properties
+++ b/plugins/org.jboss.tools.jst.jsdt/build.properties
@@ -1,5 +1,6 @@
-source.. = 
+source.. = src/
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               plugin.xml
+               plugin.xml,\
+               about.html


### PR DESCRIPTION
...ies.

Source folder is added to build.properties

Signed-off-by: vrubezhny vrubezhny@exadel.com
