### PR TITLE
JBIDE-17169 HTML5 Palette templates should be available for content assist by key words

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/plugin.xml
+++ b/plugins/org.jboss.tools.jst.web.ui/plugin.xml
@@ -804,61 +804,209 @@
 
    <extension
          point="org.jboss.tools.common.model.ui.InsertTagWizard">
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/0.JS#CSS" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.AddJSCSSREferencesWizard"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/1.Page" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPageWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/2.Dialog" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewDialogWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/3.Popup" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPopupWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/4.Grid" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGridWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/6.Panel" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/7.Table" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTableWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/8.Collapsible_Content_Block" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/9.Collapsible_Set" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleSetWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/1.Header_Bar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderBarWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/2.Footer_Bar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/3.Navbar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewNavbarWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/4.Select_Menu" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewSelectMenuWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/5.Listview" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewListviewWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/01.Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/02.Grouped_Buttons" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedButtonsWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/021.Form_Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFormButtonWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/03.Link" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewLinkWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/04.Flip_Toggle_Switch" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewToggleWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/05.Radio_Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRadioWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/06.Checkbox" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCheckBoxWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/07.Grouped_Checkboxes" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedCheckboxesWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/08.Range_Slider" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRangeSliderWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/09.Text_Input" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTextInputWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/0.JS#CSS" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.AddJSCSSREferencesWizard"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/1.Page" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPageWizard" 
+      	keywords="page"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/2.Dialog" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewDialogWizard" 
+      	keywords="dialog"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/3.Popup" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPopupWizard" 
+      	keywords="div,popup"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/4.Grid" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGridWizard" 
+      	keywords="div,grid"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/6.Panel" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelWizard" 
+      	keywords="div,panel"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/7.Table" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTableWizard"
+      	keywords="table"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/8.Collapsible_Content_Block" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleWizard" 
+      	keywords="fieldset,collapsible"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/1.page/9.Collapsible_Set" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleSetWizard" 
+      	keywords="div,collapsible,set"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/1.Header_Bar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderBarWizard" 
+      	keywords="div,header,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/2.Footer_Bar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterWizard" 
+      	keywords="div,footer,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/3.Navbar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewNavbarWizard" 
+      	keywords="div,navbar,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/4.Select_Menu" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewSelectMenuWizard" 
+      	keywords="div,select,menu"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/2.lists/5.Listview" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewListviewWizard" 
+      	keywords="ol,ul,listview,view"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/01.Button" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizard" 
+      	keywords="a,button"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/02.Grouped_Buttons" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedButtonsWizard"
+      	keywords="a,grouped,buttons" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/021.Form_Button" 
+      	keywords="input,form,button"
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFormButtonWizard" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/03.Link" 
+      	keywords="a,link"
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewLinkWizard" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/04.Flip_Toggle_Switch" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewToggleWizard" 
+      	keywords="div,flip,toggle,switch,input"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/05.Radio_Button" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRadioWizard" 
+      	keywords="input,radio,button"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/06.Checkbox" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCheckBoxWizard" 
+      	keywords="input,checkbox"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/07.Grouped_Checkboxes" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedCheckboxesWizard"
+      	keywords="input,grouped,checkbox" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/08.Range_Slider" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRangeSliderWizard"
+      	keywords="input,range,slider" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.3/3.buttons/09.Text_Input" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTextInputWizard" 
+      	keywords="input,text"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
 
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/0.JS#CSS" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.AddJSCSSREferencesWizard"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/1.Page" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPageWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/2.Dialog" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewDialogWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/3.Popup" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPopupWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/4.Grid" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGridWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/6.Panel" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/7.Table" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTableWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/8.Collapsible_Content_Block" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/9.Collapsible_Set" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleSetWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/91.Tabs" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTabsWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/92.Heading" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeadingWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/1.Header_Bar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderBarWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/2.Footer_Bar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/3.Navbar" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewNavbarWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/4.Select_Menu" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewSelectMenuWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/5.Listview" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewListviewWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/01.Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/02.Grouped_Buttons" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedButtonsWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/021.Form_Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFormButtonWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/03.Link" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewLinkWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/04.Flip_Toggle_Switch" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewToggleWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/05.Radio_Button" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRadioWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/06.Checkbox" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCheckBoxWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/07.Grouped_Checkboxes" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedCheckboxesWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/08.Range_Slider" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRangeSliderWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
-      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/09.Text_Input" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTextInputWizard" corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/0.JS#CSS" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.AddJSCSSREferencesWizard"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/1.Page" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPageWizard" 
+      	keywords="div,page"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/2.Dialog" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewDialogWizard" 
+      	keywords="div,dialog"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPagePositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/3.Popup" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPopupWizard" 
+      	keywords="div,popup"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/4.Grid" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGridWizard" 
+      	keywords="div,grid"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/6.Panel" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelWizard" 
+      	keywords="div,panel"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewPanelPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/7.Table" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTableWizard" 
+      	keywords="table"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/8.Collapsible_Content_Block" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleWizard" 
+      	keywords="fieldset,collapsible"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/9.Collapsible_Set" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCollapsibleSetWizard" 
+      	keywords="div,collapsible,set"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/91.Tabs" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTabsWizard" 
+      	keywords="div,tabs"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/1.page/92.Heading" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeadingWizard" 
+      	keywords="div,heading"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/1.Header_Bar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderBarWizard" 
+      	keywords="div,header,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewHeaderPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/2.Footer_Bar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterWizard" 
+      	keywords="div,footer,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFooterPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/3.Navbar" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewNavbarWizard" 
+      	keywords="div,navbar,bar"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/4.Select_Menu" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewSelectMenuWizard"
+      	keywords="div,select,menu" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/2.lists/5.Listview" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewListviewWizard" 
+      	keywords="ol,ul,listview,view"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/01.Button" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewButtonWizard" 
+      	keywords="a,button"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/02.Grouped_Buttons" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedButtonsWizard" 
+      	keywords="div,grouped,buttons"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/021.Form_Button" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFormButtonWizard" 
+      	keywords="input,form,button,submit"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/03.Link" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewLinkWizard" 
+      	keywords="a,link"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/04.Flip_Toggle_Switch" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewToggleWizard" 
+      	keywords="div,flip,toggle,switch,input"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/05.Radio_Button" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRadioWizard" 
+      	keywords="input,radio,button"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/06.Checkbox" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewCheckBoxWizard" 
+      	keywords="input,checkbox"
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/07.Grouped_Checkboxes" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewGroupedCheckboxesWizard"
+      	keywords="input,grouped,checkbox" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/08.Range_Slider" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewRangeSliderWizard" 
+      	keywords="input,range,slider" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
+      <tag name="_Palette_/Mobile/jQuery_Mobile/version:1.4/3.buttons/09.Text_Input" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewTextInputWizard"
+      	keywords="input,text" 
+      	corrector-class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewWidgetPositionCorrector"/>
 
       <tag name="_Palette_/Mobile/z.HTML/version:5.0/1.form/1.Form" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewFormWizard"/>
       <tag name="_Palette_/Mobile/z.HTML/version:5.0/1.form/2.Label" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewLabelWizard"/>
-      <tag name="_Palette_/Mobile/z.HTML/version:5.0/2.multimedia/1.Image" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewImageWizard"/>
+      <tag name="_Palette_/Mobile/z.HTML/version:5.0/2.multimedia/1.Image" 
+      	keywords="img,image" 
+      	class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewImageWizard"/>
       <tag name="_Palette_/Mobile/z.HTML/version:5.0/2.multimedia/2.Video" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewVideoWizard"/>
       <tag name="_Palette_/Mobile/z.HTML/version:5.0/2.multimedia/3.Audio" class="org.jboss.tools.jst.web.ui.palette.html.jquery.wizard.NewAudioWizard"/>
    </extension>

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/PaletteManager.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/PaletteManager.java
@@ -17,6 +17,7 @@ import java.util.List;
 import org.jboss.tools.common.model.XModelObject;
 import org.jboss.tools.common.model.XModelObjectConstants;
 import org.jboss.tools.common.model.options.PreferenceModelUtilities;
+import org.jboss.tools.common.model.ui.views.palette.PaletteInsertManager;
 import org.jboss.tools.jst.web.ui.internal.editor.jspeditor.dnd.MobilePaletteInsertHelper;
 import org.jboss.tools.jst.web.ui.palette.model.PaletteModel;
 
@@ -115,7 +116,12 @@ public class PaletteManager {
 			if(name.indexOf('.') >= 0) {
 				name = name.substring(name.indexOf('.') + 1);
 			}
-			result.add(new RunnablePaletteItem(category, version, name));
+			RunnablePaletteItem item = new RunnablePaletteItem(category, version, name);
+			List<String> ls = PaletteInsertManager.getInstance().getKeyWords(g.getPath());
+			if(ls != null && !ls.isEmpty()) {
+				item.getAlternatives().addAll(ls);
+			}
+			result.add(item);
 		} else {
 			for (int i = 0; i < cs.length; i++) {
 				collectItems(result, category, version, cs[i]);

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/PaletteTagLibrary.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/PaletteTagLibrary.java
@@ -88,6 +88,9 @@ public abstract class PaletteTagLibrary extends CustomTagLibrary {
 		proposal.setImageDescriptor(getImage());
 		proposal.setRelevance(getRelevance());
 		proposal.setAlternateMatch(trim(startText));
+		if(!item.getAlternatives().isEmpty()) {
+			proposal.getAlternativeMatches().addAll(item.getAlternatives());
+		}
 		proposal.setFilterable(false);
 		proposal.setExecutable(item);
 		return proposal;

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/RunnablePaletteItem.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/internal/RunnablePaletteItem.java
@@ -10,6 +10,9 @@
  ******************************************************************************/ 
 package org.jboss.tools.jst.web.ui.palette.internal;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.eclipse.jface.text.BadLocationException;
 import org.eclipse.jface.text.IDocument;
 import org.eclipse.ui.texteditor.ITextEditor;
@@ -32,6 +35,7 @@ public class RunnablePaletteItem implements IExecutableTextProposal {
 	String category;
 	String version;
 	String name;
+	List<String> alternatives = new ArrayList<String>();
 
 	public RunnablePaletteItem(String category, String version, String name) {
 		this.category = category;
@@ -61,6 +65,14 @@ public class RunnablePaletteItem implements IExecutableTextProposal {
 	 */
 	public String getName() {
 		return name;
+	}
+
+	/**
+	 * List of logic names by which this item can be invoked.
+	 * @return
+	 */
+	public List<String> getAlternatives() {
+		return alternatives;
 	}
 
 	/**

--- a/tests/org.jboss.tools.jst.web.ui.test/projects/SimpleProject/ca_13_templates.html
+++ b/tests/org.jboss.tools.jst.web.ui.test/projects/SimpleProject/ca_13_templates.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html> 
+<html> 
+ <head> 
+        <title>ca 13</title> 
+        <meta name="viewport" content="width=device-width, initial-scale=1"> 
+        <link rel="stylesheet" href="http://code.jquery.com/mobile/1.3.0-rc.1/jquery.mobile-1.3.0-rc.1.min.css" />
+        <script src="http://code.jquery.com/jquery-1.9.0.min.js"></script>
+        <script src="http://code.jquery.com/mobile/1.3.0-rc.1/jquery.mobile-1.3.0-rc.1.min.js"></script>
+ </head> 
+ <body>
+
+	page
+
+	dialog
+
+	popup
+
+	grid
+
+	panel
+
+	table
+
+	collapsible
+
+	header
+
+	footer
+
+	bar
+
+	navbar
+
+	select
+
+	listview
+
+	button
+
+	form
+
+	.link
+
+	toggle
+
+	radio
+
+	checkbox
+
+	grouped
+
+	slider
+
+	text
+
+	input
+
+
+	img
+	
+	image
+	
+	audio
+	
+	video
+	
+	label
+ </body>
+</html>

--- a/tests/org.jboss.tools.jst.web.ui.test/projects/SimpleProject/ca_14_templates.html
+++ b/tests/org.jboss.tools.jst.web.ui.test/projects/SimpleProject/ca_14_templates.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html> 
+<html> 
+ <head> 
+        <title>ca 14</title> 
+        <meta name="viewport" content="width=device-width, initial-scale=1"> 
+        <link rel="stylesheet" href="http://code.jquery.com/mobile/1.4.0-rc.1/jquery.mobile-1.4.0-rc.1.min.css" />
+        <script src="http://code.jquery.com/jquery-1.10.2.min.js"></script>
+        <script src="http://code.jquery.com/mobile/1.4.0-rc.1/jquery.mobile-1.4.0-rc.1.min.js"></script>
+ </head> 
+ <body>
+
+	page
+
+	popup
+
+	grid
+
+	panel
+
+	table
+
+	collapsible
+
+	tabs
+
+	heading
+
+	header
+
+	footer
+
+	bar
+
+	navbar
+
+	select
+
+	listview
+
+	button
+
+	form
+
+	.link
+
+	toggle
+
+	radio
+
+	checkbox
+
+	grouped
+
+	slider
+
+	text
+
+	input
+
+ </body>
+</html>

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteHTML5TemplatesTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteHTML5TemplatesTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.web.ui.editor.test.ca;
+
+public class CAMobilePaletteHTML5TemplatesTest extends CAMobilePaletteTemplatesTest {
+	private static final String PAGE_NAME = "ca_13_templates.html"; //$NON-NLS-1$
+
+	public CAMobilePaletteHTML5TemplatesTest() {}
+
+	public void testImageByImg() throws Exception {
+		doTestTemplate("", "img", decorateDisplay("Image"), 0);
+	}
+
+	public void testImage() throws Exception {
+		doTestTemplate("", "image", decorateDisplay("Image"), 0);
+	}
+
+	public void testLabel() throws Exception {
+		//first element is JQM Checkbox.
+		doTestTemplate("", "label", decorateDisplay("Label"), 1);
+	}
+
+	public void testAudio() throws Exception {
+		doTestTemplate("", "audio", decorateDisplay("Audio"), 0);
+	}
+
+	public void testVideo() throws Exception {
+		doTestTemplate("", "video", decorateDisplay("Video"), 0);
+	}
+
+	protected String getPageName() {
+		return PAGE_NAME;
+	}
+
+	protected String decorateDisplay(String display) {
+		return display + " - HTML 5.0";
+	}
+
+}

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteJQM13TemplatesTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteJQM13TemplatesTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.web.ui.editor.test.ca;
+
+public class CAMobilePaletteJQM13TemplatesTest extends CAMobilePaletteTemplatesTest {
+	private static final String PAGE_NAME = "ca_13_templates.html"; //$NON-NLS-1$
+
+	public CAMobilePaletteJQM13TemplatesTest() {}
+
+	public void testPage() throws Exception {
+		doTestTemplate("", "page", decorateDisplay("Page"), 0);
+	}
+
+	public void testPopup() throws Exception {
+		doTestTemplate("", "popup", decorateDisplay("Popup"), 0);
+	}
+
+	public void testGrid() throws Exception {
+		doTestTemplate("", "grid", decorateDisplay("Grid"), 0);
+	}
+
+	public void testPanel() throws Exception {
+		doTestTemplate("", "panel", decorateDisplay("Panel"), 0);
+	}
+
+	public void testTable() throws Exception {
+		doTestTemplate("", "table", decorateDisplay("Table"), 0);
+	}
+
+	public void testCollapsible() throws Exception {
+		doTestTemplate("", "collapsible", decorateDisplay("Collapsible Content Block"), 0);
+	}
+
+	public void testCollapsible1() throws Exception {
+		doTestTemplate("", "collapsible", decorateDisplay("Collapsible Set"), 1);
+	}
+
+	public void testHeader() throws Exception {
+		doTestTemplate("", "header", decorateDisplay("Header Bar"), 0);
+	}
+
+	public void testFooter() throws Exception {
+		doTestTemplate("", "footer", decorateDisplay("Footer Bar"), 0);
+	}
+
+	public void testBar() throws Exception {
+		doTestTemplate("", "bar", decorateDisplay("Footer Bar"), 0);
+	}
+
+	public void testBar1() throws Exception {
+		doTestTemplate("", "bar", decorateDisplay("Header Bar"), 1);
+	}
+
+	public void testNavbar() throws Exception {
+		doTestTemplate("", "navbar", decorateDisplay("Navbar"), 0);
+	}
+
+	public void testSelect() throws Exception {
+		doTestTemplate("", "select", decorateDisplay("Select Menu"), 0);
+	}
+
+	public void testListview() throws Exception {
+		doTestTemplate("", "listview", decorateDisplay("Listview"), 0);
+	}
+
+	public void testButton() throws Exception {
+		doTestTemplate("", "button", decorateDisplay("Button"), 0);
+	}
+
+	public void testForm() throws Exception {
+		doTestTemplate("", "form", decorateDisplay("Form Button"), 1);
+	}
+
+	public void testLink() throws Exception {
+		doTestTemplate(".", "link", decorateDisplay("Link"), 0);
+	}
+
+	public void testToggle() throws Exception {
+		doTestTemplate("", "toggle", decorateDisplay("Flip Toggle Switch"), 0);
+	}
+
+	public void testRadio() throws Exception {
+		doTestTemplate("", "radio", decorateDisplay("Radio Button"), 0);
+	}
+
+	public void testCheckbox() throws Exception {
+		doTestTemplate("", "checkbox", decorateDisplay("Checkbox"), 0);
+	}
+
+	public void testCheckbox1() throws Exception {
+		doTestTemplate("", "checkbox", decorateDisplay("Grouped Checkboxes"), 1);
+	}
+
+	public void testGrouped() throws Exception {
+		doTestTemplate("", "grouped", decorateDisplay("Grouped Buttons"), 0);
+	}
+
+	public void testGrouped1() throws Exception {
+		doTestTemplate("", "grouped", decorateDisplay("Grouped Checkboxes"), 1);
+	}
+
+	public void testSlider() throws Exception {
+		doTestTemplate("", "slider", decorateDisplay("Range Slider"), 0);
+	}
+
+	public void testText() throws Exception {
+		doTestTemplate("", "text", decorateDisplay("Text Input"), 0);
+	}
+
+	public void testInput() throws Exception {
+		doTestTemplate("", "input", decorateDisplay("Text Input"), 6);
+	}
+
+	protected String getPageName() {
+		return PAGE_NAME;
+	}
+
+	protected String decorateDisplay(String display) {
+		return display + " - jQuery Mobile 1.3";
+	}
+
+}

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteJQM14TemplatesTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteJQM14TemplatesTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.web.ui.editor.test.ca;
+
+public class CAMobilePaletteJQM14TemplatesTest extends CAMobilePaletteTemplatesTest {
+	private static final String PAGE_NAME = "ca_14_templates.html"; //$NON-NLS-1$
+
+	public CAMobilePaletteJQM14TemplatesTest() {}
+
+	public void testPage() throws Exception {
+		doTestTemplate("", "page", decorateDisplay("Page"), 0);
+	}
+
+	public void testPopup() throws Exception {
+		doTestTemplate("", "popup", decorateDisplay("Popup"), 0);
+	}
+
+	public void testGrid() throws Exception {
+		doTestTemplate("", "grid", decorateDisplay("Grid"), 0);
+	}
+
+	public void testPanel() throws Exception {
+		doTestTemplate("", "panel", "Panel - jQuery Mobile 1.4", 0);
+	}
+
+	public void testTable() throws Exception {
+		doTestTemplate("", "table", decorateDisplay("Table"), 0);
+	}
+
+	public void testCollapsible() throws Exception {
+		doTestTemplate("", "collapsible", decorateDisplay("Collapsible Content Block"), 0);
+	}
+
+	public void testCollapsible1() throws Exception {
+		doTestTemplate("", "collapsible", decorateDisplay("Collapsible Set"), 1);
+	}
+
+	public void testTabs() throws Exception {
+		doTestTemplate("", "tabs", decorateDisplay("Tabs"), 0);
+	}
+
+	public void testHeading() throws Exception {
+		doTestTemplate("", "heading", decorateDisplay("Heading"), 0);
+	}
+
+	public void testHeader() throws Exception {
+		doTestTemplate("", "header", decorateDisplay("Header Bar"), 0);
+	}
+
+	public void testFooter() throws Exception {
+		doTestTemplate("", "footer", decorateDisplay("Footer Bar"), 0);
+	}
+
+	public void testBar() throws Exception {
+		doTestTemplate("", "bar", decorateDisplay("Footer Bar"), 0);
+	}
+
+	public void testBar1() throws Exception {
+		doTestTemplate("", "bar", "Header Bar - jQuery Mobile 1.4", 1);
+	}
+
+	public void testNavbar() throws Exception {
+		doTestTemplate("", "navbar", decorateDisplay("Navbar"), 0);
+	}
+
+	public void testSelect() throws Exception {
+		doTestTemplate("", "select", decorateDisplay("Select Menu"), 0);
+	}
+
+	public void testListview() throws Exception {
+		doTestTemplate("", "listview", decorateDisplay("Listview"), 0);
+	}
+
+	public void testButton() throws Exception {
+		doTestTemplate("", "button", decorateDisplay("Button"), 0);
+	}
+
+	public void testForm() throws Exception {
+		doTestTemplate("", "form", decorateDisplay("Form Button"), 1);
+	}
+
+	public void testLink() throws Exception {
+		doTestTemplate(".", "link", decorateDisplay("Link"), 0);
+	}
+
+	public void testToggle() throws Exception {
+		doTestTemplate("", "toggle", decorateDisplay("Flip Toggle Switch"), 0);
+	}
+
+	public void testRadio() throws Exception {
+		doTestTemplate("", "radio", decorateDisplay("Radio Button"), 0);
+	}
+
+	public void testCheckbox() throws Exception {
+		doTestTemplate("", "checkbox", decorateDisplay("Checkbox"), 0);
+	}
+
+	public void testCheckbox1() throws Exception {
+		doTestTemplate("", "checkbox", decorateDisplay("Grouped Checkboxes"), 1);
+	}
+
+	public void testGrouped() throws Exception {
+		doTestTemplate("", "grouped", decorateDisplay("Grouped Buttons"), 0);
+	}
+
+	public void testGrouped1() throws Exception {
+		doTestTemplate("", "grouped", decorateDisplay("Grouped Checkboxes"), 1);
+	}
+
+	public void testSlider() throws Exception {
+		doTestTemplate("", "slider", decorateDisplay("Range Slider"), 0);
+	}
+
+	public void testText() throws Exception {
+		doTestTemplate("", "text", decorateDisplay("Text Input"), 0);
+	}
+
+	public void testInput() throws Exception {
+		doTestTemplate("", "input", decorateDisplay("Text Input"), 6);
+	}
+
+	protected String getPageName() {
+		return PAGE_NAME;
+	}
+
+	protected String decorateDisplay(String display) {
+		return display + " - jQuery Mobile 1.4";
+	}
+
+}

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteTemplatesTest.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/editor/test/ca/CAMobilePaletteTemplatesTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2014 Red Hat, Inc.
+ * Distributed under license by Red Hat, Inc. All rights reserved.
+ * This program is made available under the terms of the
+ * Eclipse Public License v1.0 which accompanies this distribution,
+ * and is available at http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributor:
+ *     Red Hat, Inc. - initial API and implementation
+ ******************************************************************************/
+package org.jboss.tools.jst.web.ui.editor.test.ca;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import org.eclipse.jface.text.BadLocationException;
+import org.eclipse.jface.text.FindReplaceDocumentAdapter;
+import org.eclipse.jface.text.IRegion;
+import org.eclipse.jface.text.contentassist.ICompletionProposal;
+import org.jboss.tools.common.base.test.contentassist.CATestUtil;
+import org.jboss.tools.jst.jsp.test.ca.ContentAssistantTestCase;
+import org.jboss.tools.test.util.ProjectImportTestSetup;
+
+public abstract class CAMobilePaletteTemplatesTest extends ContentAssistantTestCase {
+	   private static final String PROJECT_NAME = "SimpleProject"; //$NON-NLS-1$
+
+	public CAMobilePaletteTemplatesTest() {}
+
+	
+	public void setUp() throws Exception {
+		project = ProjectImportTestSetup.loadProject(PROJECT_NAME);
+	}
+
+	public void tearDown() throws Exception {
+		closeEditor();
+		super.tearDown();
+	}
+
+	protected abstract String getPageName();
+
+	protected String decorateDisplay(String display) {
+		return display;
+	}
+
+	public void doTestTemplate(String prefix, String template, String expectedDisplayString, int expectedIndexInList) throws Exception {
+		openEditor(getPageName());
+		assertNotNull("Document must not be null", document);
+		String search = prefix + template;
+
+		IRegion reg = null;
+		try {
+			reg = new FindReplaceDocumentAdapter(this.document).find(0, search, true, false, false, false); //$NON-NLS-1$
+		} catch (BadLocationException e) {
+			fail("Cannot find start of value text: " + e.getLocalizedMessage());
+			}
+		assertNotNull("Cannot find a text region to test", reg);
+		int start = reg.getOffset() + search.length();
+		   
+		List<ICompletionProposal> res = new ArrayList<ICompletionProposal>(CATestUtil.collectProposals(contentAssistant, viewer, start));
+		removeCopiesByDisplay(res);
+
+		assertFalse(res.isEmpty());
+		assertEquals(expectedDisplayString, res.get(expectedIndexInList).getDisplayString());		
+	}
+
+	private void removeCopiesByDisplay(List<ICompletionProposal> res) {
+		Set<String> set = new HashSet<String>();
+		Iterator<ICompletionProposal> i = res.iterator();
+		while(i.hasNext()) {
+			String s = i.next().getDisplayString();
+			if(set.contains(s)) {
+				i.remove();
+			} else {
+				set.add(s);
+			}
+		}
+	}
+}

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/JstWebUiAllTests.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/JstWebUiAllTests.java
@@ -14,6 +14,10 @@ import junit.framework.Test;
 import junit.framework.TestSuite;
 
 import org.jboss.tools.common.base.test.model.XProjectImportTestSetUp;
+import org.jboss.tools.jst.web.ui.editor.test.ca.CAMobilePaletteHTML5TemplatesTest;
+import org.jboss.tools.jst.web.ui.editor.test.ca.CAMobilePaletteJQM13TemplatesTest;
+import org.jboss.tools.jst.web.ui.editor.test.ca.CAMobilePaletteJQM14TemplatesTest;
+import org.jboss.tools.jst.web.ui.editor.test.ca.CAMobilePaletteTemplatesTest;
 import org.jboss.tools.test.util.ProjectImportTestSetup;
 
 /**
@@ -26,6 +30,9 @@ public class JstWebUiAllTests {
 		TestSuite suite = new TestSuite(JstWebUiAllTests.class.getName());
 
 		TestSuite s = new TestSuite("Palette content");
+		s.addTestSuite(CAMobilePaletteJQM14TemplatesTest.class);
+		s.addTestSuite(CAMobilePaletteJQM13TemplatesTest.class);
+		s.addTestSuite(CAMobilePaletteHTML5TemplatesTest.class);
 		s.addTestSuite(JBossToolsEditorTest.class);
 		s.addTestSuite(MobilePaletteInsertPositionTest.class);
 		s.addTestSuite(InsertJSCSSPaletteEntryTest.class);


### PR DESCRIPTION
Added keywords to Mobile Palette items. Modified xml tag completion
proposal computer to apply keyword when cursor is within a text node
to proposals and set high relevance to those having the keyword.
Tests are added.
