### PR TITLE
JBIDE-16096 JSF Code completion does not support http://xmlns.jcp.org/jsf/* namespaces

### DIFF
--- a/features/org.jboss.tools.jst.test.feature/feature.xml
+++ b/features/org.jboss.tools.jst.test.feature/feature.xml
@@ -14,7 +14,7 @@
    </license>
 
 	<plugin id="org.jboss.tools.jst.jsp.base.test" download-size="0" install-size="0" version="0.0.0" />
-	<plugin id="org.jboss.tools.jst.web.kb.test" download-size="0" install-size="0" version="0.0.0" />
+	<plugin id="org.jboss.tools.jst.web.kb.test" download-size="0" install-size="0" version="0.0.0" unpack="false"/>
 	<plugin id="org.jboss.tools.jst.web.test" download-size="0" install-size="0" version="0.0.0" />
 	<plugin id="org.jboss.tools.jst.web.ui.test" download-size="0" install-size="0" version="0.0.0" />
 

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/StaticLibraries.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/StaticLibraries.java
@@ -19,6 +19,7 @@ import java.util.Set;
 
 import org.eclipse.core.runtime.Path;
 import org.jboss.tools.common.model.XModelObject;
+import org.jboss.tools.common.model.filesystems.impl.FolderImpl;
 import org.jboss.tools.common.model.util.EclipseResourceUtil;
 import org.jboss.tools.jst.web.kb.internal.scanner.LoadedDeclarations;
 import org.jboss.tools.jst.web.kb.internal.scanner.XMLScanner;
@@ -60,6 +61,12 @@ public class StaticLibraries {
 		XModelObject o = loadedFolders.get(folder);
 		if(o != null) {
 			XModelObject fo = o.getChildByPath(file.getName());
+			if(fo == null) {
+				if (o instanceof FolderImpl) {
+					((FolderImpl)o).update();
+					fo = o.getChildByPath(file.getName());
+				}
+			}
 			if (fo != null) {
 				loadedFiles.put(file, fo);
 				XMLScanner scanner = new XMLScanner();

--- a/tests/org.jboss.tools.jst.web.kb.test/build.properties
+++ b/tests/org.jboss.tools.jst.web.kb.test/build.properties
@@ -3,10 +3,12 @@ bin.includes = META-INF/,\
                projects/,\
                .,\
                plugin.properties,\
-               plugin.xml
+               plugin.xml,\
+               taglibs/
 src.includes = src/,\
                projects/,\
                build.properties,\
-               META-INF/
+               META-INF/,\
+               taglibs/
 source.. = src/
 additional.bundles = org.jboss.tools.common.model

--- a/tests/org.jboss.tools.jst.web.kb.test/plugin.xml
+++ b/tests/org.jboss.tools.jst.web.kb.test/plugin.xml
@@ -28,6 +28,19 @@
 	        	<attribute name="template" />
 			</tag>
 		</include>
+
    </extension>
 
+  <extension point="org.eclipse.wst.xml.core.catalogContributions">
+    <catalogContribution id="default">
+         <uri 
+            name="http://jboss.tools.org/webkb/lib1" 
+            uri="platform:/plugin/org.jboss.tools.jst.web.kb.test/taglibs/lib1.taglib.xml"/>
+
+         <uri 
+            name="http://jboss.tools.org/webkb/lib2" 
+            uri="platform:/plugin/org.jboss.tools.jst.web.kb.test/taglibs/lib2.taglib.xml"/>
+	</catalogContribution>
+
+ </extension>
 </plugin>

--- a/tests/org.jboss.tools.jst.web.kb.test/taglibs/lib1.taglib.xml
+++ b/tests/org.jboss.tools.jst.web.kb.test/taglibs/lib1.taglib.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<facelet-taglib xmlns="http://java.sun.com/xml/ns/javaee"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facelettaglibrary_2_0.xsd"
+                version="2.0">
+    <description>
+        This tag library contains JavaServer Faces component tags for all
+        UIComponent + HTML RenderKit Renderer combinations defined in the
+        JavaServer Faces Specification.
+    </description>
+    <namespace>http://jboss.tools.org/webkb/lib1</namespace>
+    <tag>
+        <description>
+            <![CDATA[description goes here]]>
+        </description>
+        <tag-name>
+            button
+        </tag-name>
+        <component>
+            <component-type>javax.faces.HtmlOutcomeTargetButton</component-type>
+            <renderer-type>javax.faces.Button</renderer-type>
+        </component>
+        <attribute>
+            <description>
+                <![CDATA[description goes here]]>
+            </description>
+            <name>
+                fragment
+            </name>
+            <required>
+                false
+            </required>
+            <type>
+                java.lang.String
+            </type>
+        </attribute>
+    </tag>
+</facelet-taglib>

--- a/tests/org.jboss.tools.jst.web.kb.test/taglibs/lib2.taglib.xml
+++ b/tests/org.jboss.tools.jst.web.kb.test/taglibs/lib2.taglib.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<facelet-taglib xmlns="http://java.sun.com/xml/ns/javaee"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-facelettaglibrary_2_0.xsd"
+                version="2.0">
+    <description>
+        This tag library contains JavaServer Faces component tags for all
+        UIComponent + HTML RenderKit Renderer combinations defined in the
+        JavaServer Faces Specification.
+    </description>
+    <namespace>http://jboss.tools.org/webkb/lib2</namespace>
+    <tag>
+        <description>
+            <![CDATA[description goes here]]>
+        </description>
+        <tag-name>
+            button
+        </tag-name>
+        <component>
+            <component-type>javax.faces.HtmlOutcomeTargetButton</component-type>
+            <renderer-type>javax.faces.Button</renderer-type>
+        </component>
+        <attribute>
+            <description>
+                <![CDATA[description goes here]]>
+            </description>
+            <name>
+                fragment
+            </name>
+            <required>
+                false
+            </required>
+            <type>
+                java.lang.String
+            </type>
+        </attribute>
+    </tag>
+</facelet-taglib>


### PR DESCRIPTION
Provided update of temp folder for taglibs copied from jars.
