### PR TITLE
JBIDE-17479 Add reference to JS/CSS dialog is empty

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/jquery/wizard/JQueryVersionPage.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/jquery/wizard/JQueryVersionPage.java
@@ -67,26 +67,7 @@ public class JQueryVersionPage extends AbstractWizardPageWithPreview implements 
 
 	public void setVisible(boolean b) {
 		if(b && getWizard().getPages()[0] != this) {
-			if(!isPreviewPanelVisible) {
-				GridData d = (GridData)scale.getLayoutData();
-				d.widthHint = -1;
-				panel.update();
-				panel.layout(true);
-			} else {
-				panel.update();
-				panel.layout(true);
-				Composite l = ((AbstractNewHTMLWidgetWizardPage)getWizard().getPages()[0]).getLeftPanel();
-				int delta = l.getSize().x - left.computeSize(-1, -1).x;
-				GridData d = (GridData)scale.getLayoutData();
-				int s = scale.getSize().x + delta;
-				if(s < 400) {
-					d.widthHint = s;
-				} else {
-					d.widthHint = -1;
-				}
-				panel.update();
-				panel.layout(true);
-			}
+			panel.getShell().layout(true, true);
 		}
 		super.setVisible(b);
 		if(b) {

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractNewHTMLWidgetWizard.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractNewHTMLWidgetWizard.java
@@ -65,6 +65,12 @@ public class AbstractNewHTMLWidgetWizard extends Wizard implements PropertyChang
 	protected IDropCommand command;
 	Set<String> ids = new HashSet<String>();
 
+	/**
+	 * Shared by all pages width of left panel, computed once and then used 
+	 * when preview is shown. 
+	 */
+	protected int leftPanelWidth = -1;
+
 	public AbstractNewHTMLWidgetWizard() {}
 
 	@Override
@@ -82,6 +88,16 @@ public class AbstractNewHTMLWidgetWizard extends Wizard implements PropertyChang
 
 	protected void doAddPages() {
 		
+	}
+
+	public int getLeftPanelWidth() {
+		return leftPanelWidth;
+	}
+
+	public void setLeftPanelWidth(int w, boolean force) {
+		if((force || leftPanelWidth < 0) && w > 0) {
+			leftPanelWidth = w;
+		}
 	}
 
 	@Override

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractWizardPageWithPreview.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/wizard/AbstractWizardPageWithPreview.java
@@ -58,15 +58,15 @@ public abstract class AbstractWizardPageWithPreview extends DefaultDropWizardPag
 		panel.setLayout(layout);
 
 		left = new Composite(panel, SWT.BORDER) {
-			int initialDefaultWidth = -1;
 			@Override
 			public Point computeSize(int wHint, int hHint, boolean changed) {
 				Point result = super.computeSize(wHint, hHint, changed);
-				if(hHint < 0) {
-					if(initialDefaultWidth < 0) {
-						initialDefaultWidth = result.x;
-					} else if(result.x > initialDefaultWidth) {
-						result.x = initialDefaultWidth;
+				if(hHint < 0 && (getWizard() instanceof AbstractNewHTMLWidgetWizard)) {
+					AbstractNewHTMLWidgetWizard w = (AbstractNewHTMLWidgetWizard)getWizard();
+					if(w.getLeftPanelWidth() < 0) {
+						w.setLeftPanelWidth(result.x, false);
+					} else {
+						result.x = w.getLeftPanelWidth();
 					}
 				}
 				return result;


### PR DESCRIPTION
Algorithm for controlling left panel of wizard is modified
and checked both for Linux and Mac OS.
