### PR TITLE
JBIDE-18081 Ionic palette wizards do not insert selected js/css links into html template

### DIFF
--- a/plugins/org.jboss.tools.jst.angularjs/src/org/jboss/tools/jst/angularjs/internal/ionic/palette/wizard/NewIonicWidgetWizard.java
+++ b/plugins/org.jboss.tools.jst.angularjs/src/org/jboss/tools/jst/angularjs/internal/ionic/palette/wizard/NewIonicWidgetWizard.java
@@ -82,6 +82,7 @@ public abstract class NewIonicWidgetWizard<P extends NewIonicWidgetWizardPage> e
 		preferredVersions.saveLibPreference();
 		if(page == null || isTrue(AbstractNewHTMLWidgetWizardPage.ADD_JS_CSS_SETTING_NAME)) {
 			getCommandProperties().put(MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS, getVersion());
+			getCommandProperties().put(MobilePaletteInsertHelper.PROPOPERTY_PREFERRED_JS_LIB_VERSIONS, preferredVersions);
 		}
 		super.doPerformFinish();
 	}

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/jspeditor/dnd/MobilePaletteInsertHelper.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/jspeditor/dnd/MobilePaletteInsertHelper.java
@@ -46,6 +46,7 @@ import org.w3c.dom.NodeList;
 
 public class MobilePaletteInsertHelper extends PaletteInsertHelper {
 	public static final String PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS   = "insert jquery mobile js css"; //$NON-NLS-1$
+	public static final String PROPOPERTY_PREFERRED_JS_LIB_VERSIONS = "preferred-js-lib-versions";
 	
 	// palettePath - %Palette%/Mobile/jQuery Mobile/1.page/0. JS#CSS
 	public static final String INSERT_JS_CSS_SIGNATURE = "<jquery.mobile.js.css>"; //$NON-NLS-1$
@@ -115,7 +116,7 @@ public class MobilePaletteInsertHelper extends PaletteInsertHelper {
 					}
 				}
 			}
-			insertJsCss(v, (IHTMLLibraryVersion)p.get(PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS));
+			insertJsCss(v, (IHTMLLibraryVersion)p.get(PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS), (PreferredJSLibVersions)p.get(PROPOPERTY_PREFERRED_JS_LIB_VERSIONS));
 			if(insert){
 				texts[0] = "";	
 			}else{
@@ -339,7 +340,7 @@ public class MobilePaletteInsertHelper extends PaletteInsertHelper {
 		return number;
 	}
 	
-	private void insertJsCss(ISourceViewer viewer, IHTMLLibraryVersion version) {
+	private void insertJsCss(ISourceViewer viewer, IHTMLLibraryVersion version, PreferredJSLibVersions preferredVersions) {
 		IDocument document = viewer.getDocument();
 		
 		IStructuredModel model = null;
@@ -371,8 +372,10 @@ public class MobilePaletteInsertHelper extends PaletteInsertHelper {
 				
 				boolean metaExists = checkNode(headNode, "meta", "name", "(viewport)");
 				
-				PreferredJSLibVersions preferredVersions = new PreferredJSLibVersions(MarkerResolutionUtils.getFile(), version);
-				preferredVersions.updateLibEnablementAndSelection();
+				if(preferredVersions == null) {
+					preferredVersions = new PreferredJSLibVersions(MarkerResolutionUtils.getFile(), version);
+					preferredVersions.updateLibEnablementAndSelection();
+				}
 				String[][] urls = preferredVersions.getURLs(headNode);
 				
 				// insert tags if needed

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/jspeditor/dnd/PaletteDropCommand.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/jspeditor/dnd/PaletteDropCommand.java
@@ -119,12 +119,17 @@ public class PaletteDropCommand extends FileDropCommand {
 		}
 	}
 
+	static String[] PROPERTIES_FOR_RUN = new String[]{
+		SharableConstants.PALETTE_PATH,
+		MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS,
+		MobilePaletteInsertHelper.PROPOPERTY_PREFERRED_JS_LIB_VERSIONS
+	};
+
 	protected void fillPropertiesForRun(Properties properties) {
-		if(this.properties.containsKey(SharableConstants.PALETTE_PATH)) {
-			properties.put(SharableConstants.PALETTE_PATH, this.properties.getProperty(SharableConstants.PALETTE_PATH));
-		}
-		if(this.properties.containsKey(MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS)) {
-			properties.put(MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS, this.properties.get(MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS));
+		for (String name: PROPERTIES_FOR_RUN) {
+			if(this.properties.containsKey(name)) {
+				properties.put(name, this.properties.get(name));
+			}
 		}
 	}
 

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/PreferredJSLibVersions.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/PreferredJSLibVersions.java
@@ -24,8 +24,6 @@ import org.eclipse.core.runtime.CoreException;
 import org.eclipse.core.runtime.QualifiedName;
 import org.jboss.tools.common.xml.XMLUtilities;
 import org.jboss.tools.jst.web.html.HTMLConstants;
-import org.jboss.tools.jst.web.kb.internal.JQueryMobileRecognizer;
-import org.jboss.tools.jst.web.kb.internal.JQueryRecognizer;
 import org.jboss.tools.jst.web.kb.internal.JSRecognizer;
 import org.jboss.tools.jst.web.kb.internal.taglib.html.IHTMLLibraryVersion;
 import org.jboss.tools.jst.web.kb.internal.taglib.html.jq.JQueryMobileVersion;

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/jquery/wizard/NewJQueryWidgetWizard.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/palette/html/jquery/wizard/NewJQueryWidgetWizard.java
@@ -90,6 +90,7 @@ public abstract class NewJQueryWidgetWizard<P extends NewJQueryWidgetWizardPage>
 		preferredVersions.saveLibPreference();
 		if(page == null || isTrue(AbstractNewHTMLWidgetWizardPage.ADD_JS_CSS_SETTING_NAME)) {
 			getCommandProperties().put(MobilePaletteInsertHelper.PROPOPERTY_JQUERY_MOBILE_INSERT_JS_CSS, getVersion());
+			getCommandProperties().put(MobilePaletteInsertHelper.PROPOPERTY_PREFERRED_JS_LIB_VERSIONS, preferredVersions);
 		}
 		super.doPerformFinish();
 	}

--- a/tests/org.jboss.tools.jst.angularjs.test/src/org/jboss/tools/jst/angularjs/test/InsertJSCSSPaletteEntryTest.java
+++ b/tests/org.jboss.tools.jst.angularjs.test/src/org/jboss/tools/jst/angularjs/test/InsertJSCSSPaletteEntryTest.java
@@ -10,6 +10,8 @@
  ******************************************************************************/
 package org.jboss.tools.jst.angularjs.test;
 
+import java.util.List;
+
 import org.eclipse.jface.text.TextSelection;
 import org.eclipse.jface.wizard.IWizard;
 import org.eclipse.jface.wizard.IWizardPage;
@@ -23,6 +25,7 @@ import org.jboss.tools.jst.angularjs.internal.ionic.palette.wizard.NewContentWiz
 import org.jboss.tools.jst.angularjs.internal.ionic.palette.wizard.NewIonicWidgetWizard;
 import org.jboss.tools.jst.angularjs.internal.ionic.palette.wizard.NewTabWizardPage;
 import org.jboss.tools.jst.jsp.test.palette.AbstractPaletteEntryTest;
+import org.jboss.tools.jst.web.ui.internal.preferences.js.JSLibFactory;
 import org.jboss.tools.jst.web.ui.internal.preferences.js.PreferredJSLibVersions;
 import org.jboss.tools.jst.web.ui.palette.html.wizard.AbstractNewHTMLWidgetWizardPage;
 import org.jboss.tools.jst.web.ui.palette.html.wizard.HTMLConstants;
@@ -444,6 +447,30 @@ public class InsertJSCSSPaletteEntryTest extends AbstractPaletteEntryTest implem
 		}
 		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
 		compare(text, test_result_1Ionic);
+	}
+
+	public void testInsertIntoTemplate() {
+		editor = openEditor("ionic.html");
+		IWizardPage currentPage = runToolEntry(IonicConstants.IONIC_CATEGORY, "JS/CSS", true);
+		if(currentPage instanceof IonicVersionPage) {
+			IonicVersionPage versionPage = (IonicVersionPage)currentPage;
+			assertEquals(Boolean.FALSE, versionPage.getEditor("add Ionic").getValue());
+			versionPage.getEditor("add Ionic").setValueAsString("true");
+			assertEquals("true", versionPage.getEditor("add Ionic").getValue().toString());
+			IWizard wizard = currentPage.getWizard();
+			wizard.performFinish();
+			WizardDialog dialog = (WizardDialog)wizard.getContainer();
+			dialog.close();
+		}
+		String text = textEditor.getDocumentProvider().getDocument(textEditor.getEditorInput()).get();
+		System.out.println(text);
+		List<String> urls = JSLibFactory.getInstance()
+				.getDefaultModel()
+				.getLib(IonicConstants.IONIC_CATEGORY).getVersion(IonicVersion.getLatestDefaultVersion().toString())
+				.getURLs();
+		for (String url: urls) {
+			assertTrue(text.indexOf(url) >= 0);
+		}
 	}
 
 	public void testInsertAround(){


### PR DESCRIPTION
Model object PreferredJSLibVersions that is set in wizard is passed fo MobilePaletteInsertHelper, Previously, it was reconstructed by preferences which are ignored for html template files.
