### PR TITLE
JBIDE-18145 Remove extra added content types from JBoss Tools HTML Edito...

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/HTMLTextViewerConfiguration.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/HTMLTextViewerConfiguration.java
@@ -74,15 +74,6 @@ public class HTMLTextViewerConfiguration extends
 		super();
 	}
 
-	@Override
-	public String[] getConfiguredContentTypes(ISourceViewer sourceViewer) {
-		String[] contentTypes = super.getConfiguredContentTypes(sourceViewer);
-		String[] result = new String[contentTypes.length + 1];
-		System.arraycopy(contentTypes, 0, result, 0, contentTypes.length);
-		result[contentTypes.length] = "org.eclipse.angularjs.ANGULAR_DEFAULT";
-		return result;
-	}
-
 	protected IContentAssistProcessor[] getContentAssistProcessors(
 			ISourceViewer sourceViewer, String partitionType) {
 		return new IContentAssistProcessor[] { 


### PR DESCRIPTION
...r's Text Viewer Configuration.

The extra Angular JS content type is removed from the HTML Editor's configured content type.

Signed-off-by: vrubezhny vrubezhny@exadel.com
