### PR TITLE
JBIDE-18209 Autoapply new default JS/CSS library preferences

### DIFF
--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/JSLibFactory.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/JSLibFactory.java
@@ -173,7 +173,11 @@ public class JSLibFactory {
 		String newText = JSLibXMLLoader.saveToString(getDefaultModel());
 		if(!f.exists()) {
 			FileUtil.writeFile(f, newText);
-			return null;
+			//Previous default model is unknown. The best way is to presume 
+			//that each artifact of the current default model is new 
+			//(so that it will be added), and each artifact in current 
+			//preferences is customized (so that it will be preserved).
+			return new JSLibModel();
 		}
 		JSLibModel oldDefaultModel = JSLibXMLLoader.load(FileUtil.readFile(f));
 		if(newDefaultModel.equals(oldDefaultModel)) {


### PR DESCRIPTION
Case of the first autoapply to workspace created with 4.2.0 beta
is covered in the same way as case of file .js-css.xml removed
from .metadata.
