### PR TITLE
JBIDE-18810 - 'Angular' plugin won't be loaded by default when Tern/Angular will be moved to 0.7.x stream

### DIFF
--- a/plugins/org.jboss.tools.jst.angularjs/plugin.xml
+++ b/plugins/org.jboss.tools.jst.angularjs/plugin.xml
@@ -80,4 +80,17 @@
 		<libs path="meta/js-css.xml"/>
 	</extension> 
 
+	<extension 
+		point="tern.eclipse.ide.core.ternNatureAdapters"
+		id="org.jboss.tools.jst.angularjs.ternNatureAdapters"
+		name="org.jboss.tools.jst.angularjs.ternNatureAdapters">
+		
+		<ternAdaptToNature 
+			id = "org.eclipse.wst.jsdt.core.jsNature"
+			name = "JavaScript">
+			<defaultModules>
+				<module name="angular" />
+			</defaultModules>
+		</ternAdaptToNature>
+	</extension>
 </plugin>


### PR DESCRIPTION
The fix makes 'angular' plug-in to be loaded into Tern.js by default

Signed-off-by: vrubezhny <vrubezhny@exadel.com>