### PR TITLE
JBIDE-18903 Refactor implementations of ITagLibRecognizer

### DIFF
--- a/plugins/org.jboss.tools.jst.angularjs/src/org/jboss/tools/jst/angularjs/internal/ionic/IonicRecognizer.java
+++ b/plugins/org.jboss.tools.jst.angularjs/src/org/jboss/tools/jst/angularjs/internal/ionic/IonicRecognizer.java
@@ -13,16 +13,19 @@ package org.jboss.tools.jst.angularjs.internal.ionic;
 import org.eclipse.core.resources.IFile;
 import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.common.util.FileUtil;
+import org.jboss.tools.jst.angularjs.internal.ionic.palette.wizard.IonicVersion;
 import org.jboss.tools.jst.web.kb.internal.AngularJSRecognizer;
 import org.jboss.tools.jst.web.kb.internal.HTMLRecognizer;
 import org.jboss.tools.jst.web.kb.internal.JSRecognizer;
 import org.jboss.tools.jst.web.kb.internal.JspContextImpl;
+import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
+import org.jboss.tools.jst.web.kb.taglib.ITagLibVersionRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
 /**
  * @author Alexey Kazakov
  */
-public class IonicRecognizer extends HTMLRecognizer {
+public class IonicRecognizer extends HTMLRecognizer implements ITagLibVersionRecognizer {
 
 	private static final String JS_LIB_NAME = "ionic";
 
@@ -37,6 +40,10 @@ public class IonicRecognizer extends HTMLRecognizer {
 		return false;
 	}
 
+	@Override
+	public IHTMLLibraryVersion getVersion(ELContext context) {
+		return isUsed(context) ? IonicVersion.IONIC_1_0 : null;
+	}
 	/**
 	 * Returns true if file has link to *.js or *.css resource 
 	 * with occurance of 'ionic' in the name of link.

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageProcessor.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/PageProcessor.java
@@ -34,6 +34,7 @@ import org.jboss.tools.jst.web.kb.taglib.IContextComponent;
 import org.jboss.tools.jst.web.kb.taglib.ICustomTagLibComponent;
 import org.jboss.tools.jst.web.kb.taglib.ICustomTagLibrary;
 import org.jboss.tools.jst.web.kb.taglib.IFacesConfigTagLibrary;
+import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibVersionRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
@@ -202,7 +203,7 @@ public class PageProcessor {
 			} else if(libs.size()>1) {
 				ICustomTagLibrary any = libs.iterator().next();
 				ITagLibRecognizer recognizer = any.getRecognizer();
-				String version = null;
+				IHTMLLibraryVersion version = null;
 				if(recognizer!=null && recognizer instanceof ITagLibVersionRecognizer) {
 					version = ((ITagLibVersionRecognizer)recognizer).getVersion(context);
 					if(version == null) {
@@ -215,7 +216,7 @@ public class PageProcessor {
 						if(shouldLoadLib(lib, context)) {
 							result.add(lib);
 						}
-					} else if(version.equals(v)) {
+					} else if(version.toString().equals(v)) {
 						result.add(lib);
 					}
 				}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/HTML5Recognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/HTML5Recognizer.java
@@ -13,17 +13,24 @@ package org.jboss.tools.jst.web.kb.internal;
 import org.eclipse.core.resources.IFile;
 import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.common.util.FileUtil;
+import org.jboss.tools.jst.web.kb.internal.taglib.html.HTMLVersion;
+import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
+import org.jboss.tools.jst.web.kb.taglib.ITagLibVersionRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
 /**
  * Recognizer for HTML5 files
  * @author Alexey Kazakov
  */
-public class HTML5Recognizer extends HTMLRecognizer {
+public class HTML5Recognizer extends HTMLRecognizer implements ITagLibVersionRecognizer {
 
 	@Override
 	protected boolean recalculateResult(ITagLibrary lib, ELContext context, IFile file) {
 		return FileUtil.isDoctypeHTML(file);
 	}
 
+	@Override
+	public IHTMLLibraryVersion getVersion(ELContext context) {
+		return isUsed(context) ? HTMLVersion.HTML_5_0 : null;
+	}
 }

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/HTMLRecognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/HTMLRecognizer.java
@@ -14,7 +14,6 @@ import org.eclipse.core.resources.IFile;
 import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.common.util.FileUtil;
 import org.jboss.tools.jst.web.kb.PageContextFactory;
-import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
@@ -70,7 +69,7 @@ public class HTMLRecognizer implements ITagLibRecognizer {
 	 * @see org.jboss.tools.jst.web.kb.taglib.ITagLibRecognizer#isUsed(org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion, org.jboss.tools.common.el.core.resolver.ELContext)
 	 */
 	@Override
-	public boolean isUsed(IHTMLLibraryVersion version, ELContext context) {
+	public boolean isUsed(ELContext context) {
 		return isUsedInternal(null, context);
 	}
 
@@ -79,7 +78,7 @@ public class HTMLRecognizer implements ITagLibRecognizer {
 	 * @see org.jboss.tools.jst.web.kb.taglib.ITagLibRecognizer#isUsed(org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion, org.eclipse.core.resources.IFile)
 	 */
 	@Override
-	public boolean isUsed(IHTMLLibraryVersion version, IFile file) {
-		return isUsed(version, PageContextFactory.createPageContext(file));
+	public boolean isUsed(IFile file) {
+		return isUsed(PageContextFactory.createPageContext(file));
 	}
 }

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JQueryMobileRecognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JQueryMobileRecognizer.java
@@ -10,7 +10,6 @@
  ******************************************************************************/ 
 package org.jboss.tools.jst.web.kb.internal;
 
-import org.eclipse.core.resources.IFile;
 import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.jst.web.kb.internal.taglib.html.jq.JQueryMobileVersion;
 import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
@@ -29,27 +28,16 @@ public class JQueryMobileRecognizer extends JSRecognizer {
 		return JQUERY_MOBILE_JS_PATTERN_START + (lib.getVersion()!=null?lib.getVersion():"") + JQUERY_MOBILE_JS_PATTERN_END;
 	}
 
-	@Override
-	public String getVersion(ELContext context) {
-		String version = getJSReferenceVersion(context.getResource(), getJSLibName());
-		if(version==null) {
-			return null;
-		}
-		if(version.equals(JQueryMobileVersion.JQM_1_3.toString())) {
-			return JQueryMobileVersion.JQM_1_3.toString();
-		}
-		return JQueryMobileVersion.JQM_1_4.toString();
-	}
-
 	/**
-	 * Returns the version of JQM declared in the file or null if there is no JQM declaration.
-	 * Returns the default version is the declared one is unknown. 
+	 * Returns the version of JQM representing the specified  version of the library.
+	 * Returns null if string version is null.
+	 * Returns the default version is the string version is unknown. 
 	 * @param context
 	 * @return
 	 */
-	public static IHTMLLibraryVersion getVersion(IFile file) {
-		String version = getJSReferenceVersion(file, JQUERY_MOBILE_JS_LIB_NAME);
-		if(version==null) {
+	@Override
+	protected IHTMLLibraryVersion findVersion(String version) {
+		if(version == null) {
 			return null;
 		}
 		if(version.equals(JQueryMobileVersion.JQM_1_3.toString())) {

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JSRecognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/JSRecognizer.java
@@ -25,7 +25,7 @@ import org.eclipse.wst.xml.core.internal.provisional.document.IDOMModel;
 import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.common.util.FileUtil;
 import org.jboss.tools.jst.web.kb.WebKbPlugin;
-import org.jboss.tools.jst.web.kb.taglib.ITagLibVersionRecognizer;
+import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
@@ -35,7 +35,7 @@ import org.w3c.dom.NodeList;
 /**
  * @author Alexey Kazakov
  */
-public abstract class JSRecognizer extends HTML5Recognizer implements ITagLibVersionRecognizer {
+public abstract class JSRecognizer extends HTML5Recognizer {
 
 	protected abstract String getJSPattern();
 	protected abstract String getJSLibName();
@@ -50,8 +50,19 @@ public abstract class JSRecognizer extends HTML5Recognizer implements ITagLibVer
 	}
 
 	@Override
-	public String getVersion(ELContext context) {
-		return getJSReferenceVersion(context.getResource(), getJSLibName());
+	public IHTMLLibraryVersion getVersion(ELContext context) {
+		return findVersion(getJSReferenceVersion(context.getResource(), getJSLibName()));
+	}
+
+	/**
+	 * Returns the IHTMLLibraryVersion representing the specified string version of the library. 
+	 * May return null or the default version (it's up to implementation) if the string version 
+	 * is null or unknown.
+	 * @param version specified string version of the library
+	 * @return
+	 */
+	protected IHTMLLibraryVersion findVersion(String version) {
+		return null;
 	}
 
 	/**

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/taglib/html/jq/JQueryMobileVersion.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/internal/taglib/html/jq/JQueryMobileVersion.java
@@ -11,6 +11,7 @@
 package org.jboss.tools.jst.web.kb.internal.taglib.html.jq;
 
 import org.eclipse.core.resources.IFile;
+import org.jboss.tools.jst.web.kb.PageContextFactory;
 import org.jboss.tools.jst.web.kb.internal.JQueryMobileRecognizer;
 import org.jboss.tools.jst.web.kb.internal.JQueryRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
@@ -95,7 +96,7 @@ public enum JQueryMobileVersion implements IHTMLLibraryVersion {
 		if(JQ_CATEGORY.equals(libName)) {
 			return JQueryRecognizer.containsJQueryJSReference(file);
 		} else if(JQM_CATEGORY.equals(libName)) {
-			return JQueryMobileRecognizer.getVersion(file) != null;
+			return new JQueryMobileRecognizer().getVersion(PageContextFactory.createPageContext(file)) != null;
 		}
 		return false;
 	}

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/ITagLibRecognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/ITagLibRecognizer.java
@@ -26,20 +26,16 @@ public interface ITagLibRecognizer {
 	boolean shouldBeLoaded(ITagLibrary lib, ELContext context);
 
 	/**
-	 * Returns true if the library with the given version is used in this context.
-	 * If version==null then the version does not matter. Any version of the library is recognized as used.
-	 * @param version
+	 * Returns true if the library is used in this context.
 	 * @param context
 	 * @return
 	 */
-	boolean isUsed(IHTMLLibraryVersion version, ELContext context);
+	boolean isUsed(ELContext context);
 
 	/**
-	 * Returns true if the library with the given version is used in this file.
-	 * If version==null then the version does not matter. Any version of the library is recognized as used.
-	 * @param version
-	 * @param context
+	 * Returns true if the library is used in this file.
+	 * @param file
 	 * @return
 	 */
-	boolean isUsed(IHTMLLibraryVersion version, IFile file);
+	boolean isUsed(IFile file);
 }

--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/ITagLibVersionRecognizer.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/ITagLibVersionRecognizer.java
@@ -22,5 +22,5 @@ public interface ITagLibVersionRecognizer extends ITagLibRecognizer {
 	 * @param context
 	 * @return
 	 */
-	String getVersion(ELContext context);
+	IHTMLLibraryVersion getVersion(ELContext context);
 }

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/PreferredJSLibVersions.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/preferences/js/PreferredJSLibVersions.java
@@ -67,11 +67,6 @@ public class PreferredJSLibVersions implements IPreferredJSLibVersion {
 		}
 		return result;
 	}
-	abstract static class DefaultJSRecognizer extends JSRecognizer {
-		public static String getJSReferenceVersion(IFile file, String jsLibName) {
-			return JSRecognizer.getJSReferenceVersion(file, jsLibName);
-		}		
-	}
 
 	public PreferredJSLibVersions(IFile file, IHTMLLibraryVersion version) {
 		f = file;
@@ -135,7 +130,7 @@ public class PreferredJSLibVersions implements IPreferredJSLibVersion {
 			} else {
 				String libNameRoot = getLibNameRoot(lib);
 				if(libNameRoot != null) {
-					enabled = f == null || DefaultJSRecognizer.getJSReferenceVersion(f, libNameRoot) == null;
+					enabled = f == null || JSRecognizer.getJSReferenceVersion(f, libNameRoot) == null;
 				}
 			}
 			if(enabled) {

--- a/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/JQueryRecognizerTest.java
+++ b/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/JQueryRecognizerTest.java
@@ -20,6 +20,7 @@ import org.jboss.tools.common.el.core.resolver.ELContext;
 import org.jboss.tools.jst.web.kb.PageContextFactory;
 import org.jboss.tools.jst.web.kb.internal.JQueryMobileRecognizer;
 import org.jboss.tools.jst.web.kb.internal.taglib.html.jq.JQueryMobileVersion;
+import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
 
 /**
  * @author Alexey Kazakov
@@ -55,7 +56,7 @@ public class JQueryRecognizerTest extends TestCase {
 		assertNotNull(context);
 
 		JQueryMobileRecognizer r = new JQueryMobileRecognizer();
-		String v = r.getVersion(context);
-		assertEquals(version.toString(), v);
+		IHTMLLibraryVersion v = r.getVersion(context);
+		assertEquals(version, v);
 	}
 }

--- a/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/palette/TestTaglibRecognizer.java
+++ b/tests/org.jboss.tools.jst.web.ui.test/src/org/jboss/tools/jst/web/ui/test/palette/TestTaglibRecognizer.java
@@ -12,7 +12,6 @@ package org.jboss.tools.jst.web.ui.test.palette;
 
 import org.eclipse.core.resources.IFile;
 import org.jboss.tools.common.el.core.resolver.ELContext;
-import org.jboss.tools.jst.web.kb.taglib.IHTMLLibraryVersion;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibRecognizer;
 import org.jboss.tools.jst.web.kb.taglib.ITagLibrary;
 
@@ -24,12 +23,12 @@ public class TestTaglibRecognizer implements ITagLibRecognizer {
 	}
 
 	@Override
-	public boolean isUsed(IHTMLLibraryVersion version, ELContext context) {
+	public boolean isUsed(ELContext context) {
 		return false;
 	}
 
 	@Override
-	public boolean isUsed(IHTMLLibraryVersion version, IFile file) {
+	public boolean isUsed(IFile file) {
 		return false;
 	}
 }


### PR DESCRIPTION
Second contribution to refactoring. Interface methods changed
boolean ITagLibRecognizer.isUsed(ELContext context);
boolean ITagLibRecognizer.isUsed(IFile file);
IHTMLLibraryVersion ITagLibVersionRecognizer.getVersion(ELContext context);
Interface ITagLibVersionRecognizer is implemented by HTMLRecognizer
and IonicRecognizer.
