### PR TITLE
JBIDE-19028 Prefix string too short prevents EL content assist with Seam taglib

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/TagLibraryManager.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/TagLibraryManager.java
@@ -172,6 +172,9 @@ public class TagLibraryManager {
 					prefix = name.substring(0, i);
 					sufix = name.substring(i);
 				}
+				while(prefix.length() < 3) {
+					prefix += "_";
+				}
 
 				WebKbPlugin plugin = WebKbPlugin.getDefault();
 				if(plugin != null) {


### PR DESCRIPTION
Lets provide minimum length of 3 by appending needed number of '_' symbols.