### PR TITLE
[JBDS-3404] Cannot update from JBDS 9.0.0.Alpha1 to Alpha2 (nightly) 

### DIFF
--- a/features/org.jboss.tools.jst.angularjs.feature/feature.xml
+++ b/features/org.jboss.tools.jst.angularjs.feature/feature.xml
@@ -17,9 +17,9 @@
       %license
    </license>
 
-   <includes
-         id="org.jboss.tools.jst.jsdt.feature"
-         version="0.0.0"/>
+   <requires>
+      <import feature="org.jboss.tools.jst.jsdt.feature" version="0.0.0" match="greaterOrEqual"/>
+   </requires>
 
    <plugin
          id="org.jboss.tools.jst.angularjs"


### PR DESCRIPTION
Fix changes dependency to org.jboss.tools.jst.jsdt feature
from inclusion to requiremement with open range.