### PR TITLE
JBIDE-20580 Performance: EL resolvers unnecessarily create a lot of empty ArrayList instances

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/include/IncludeModel.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/include/IncludeModel.java
@@ -22,6 +22,7 @@ import org.eclipse.core.runtime.IPath;
 import org.eclipse.core.runtime.Path;
 import org.jboss.tools.common.el.core.ELReference;
 import org.jboss.tools.common.el.core.parser.ELParserUtil;
+import org.jboss.tools.common.el.core.resolver.ELContextImpl;
 import org.jboss.tools.common.el.core.resolver.Var;
 import org.jboss.tools.common.xml.XMLUtilities;
 import org.jboss.tools.jst.web.kb.WebKbPlugin;
@@ -70,14 +71,18 @@ public class IncludeModel implements IIncludeModel {
 	}
 
 	public synchronized List<Var> getVars(IPath path) {
-		List<Var> result = new ArrayList<Var>();
 		List<PageInclude> is = parentReferences.get(path);
-		if(is != null) {
+		if(is == null ||is.isEmpty()) {
+			return ELContextImpl.EMPTY;
+		} else if(is.size() == 1) {
+			return is.get(0).getVars();
+		} else {
+			List<Var> result = new ArrayList<Var>();
 			for (PageInclude i: is) {
 				result.addAll(i.getVars());
 			}
+			return result;
 		}
-		return result;
 	}
 
 	static final String STORE_ELEMENT_INCLUDES = "includes"; //$NON-NLS-1$

--- a/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/contentassist/computers/XmlTagCompletionProposalComputer.java
+++ b/plugins/org.jboss.tools.jst.web.ui/src/org/jboss/tools/jst/web/ui/internal/editor/contentassist/computers/XmlTagCompletionProposalComputer.java
@@ -60,6 +60,7 @@ import org.jboss.tools.common.el.core.model.ELUtil;
 import org.jboss.tools.common.el.core.parser.ELParser;
 import org.jboss.tools.common.el.core.parser.ELParserUtil;
 import org.jboss.tools.common.el.core.resolver.ELContext;
+import org.jboss.tools.common.el.core.resolver.ELContextImpl;
 import org.jboss.tools.common.el.core.resolver.ELResolver;
 import org.jboss.tools.common.el.core.resolver.ELResolverFactoryManager;
 import org.jboss.tools.common.el.core.resolver.Var;
@@ -899,6 +900,11 @@ public class XmlTagCompletionProposalComputer  extends AbstractXmlCompletionProp
 		@Override
 		public Map<String, List<INameSpace>> getRootNameSpaces() {
 			return namespaces;
+		}
+
+		@Override
+		public List<Var> getVarsAsList(int offset) {
+			return ELContextImpl.EMPTY;
 		}
 	}
 	

--- a/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/IncludeModelTest.java
+++ b/tests/org.jboss.tools.jst.web.kb.test/src/org/jboss/tools/jst/web/kb/test/IncludeModelTest.java
@@ -70,8 +70,8 @@ public class IncludeModelTest extends TestCase {
 		
 		IFile f1 = project.getFile("WebContent/pages/params/template.xhtml");
 		ELContext context = PageContextFactory.createPageContext(f1);
-		Var[] vars1 = context.getVars(0);
-		assertEquals(6, vars1.length);
+		List<Var> vars1 = context.getVarsAsList(0);
+		assertEquals(6, vars1.size());
 		
 	}
 


### PR DESCRIPTION
ELContext.getVarsAsList(int) method is added.