### PR TITLE
JBIDE-21189 composite install jobs now depends on early access site

### DIFF
--- a/tests/org.jboss.tools.jst.angularjs.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jst.angularjs.test/META-INF/MANIFEST.MF
@@ -19,8 +19,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.common.base.test,
  org.eclipse.jface.text;bundle-version="3.9.0",
  org.jboss.tools.common.el.core;bundle-version="3.6.0",
- org.eclipse.angularjs.core;bundle-version="1.1.0",
- org.eclipse.angularjs.ui;bundle-version="1.1.0"
+ org.eclipse.angularjs.core;bundle-version="1.1.0";resolution:=optional,
+ org.eclipse.angularjs.ui;bundle-version="1.1.0";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.7
 Bundle-Vendor: %Bundle-Vendor.0


### PR DESCRIPTION
Make angular-eclipse deps optional to avoid error at install time