### PR TITLE
JBIDE-22446 use central.tpc.version =...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,8 @@
 				https://github.com/jbosstools/jbosstools-devdoc/blob/master/building/target_platforms/target_platforms_dependency_mirrors.adoc and 
 				https://github.com/jbosstools/jbosstools-devdoc/blob/master/building/target_platforms/target_platforms_updates.adoc
 		-->
-		<angularjs.repo.url>http://download.jboss.org/jbosstools/targetplatforms/jbtearlyaccesstarget/4.60.0.Alpha1-SNAPSHOT/REPO/</angularjs.repo.url>
+		<central.tpc.version>4.60.0.Final-SNAPSHOT</central.tpc.version>
+		<angularjs.repo.url>http://download.jboss.org/jbosstools/targetplatforms/jbtearlyaccesstarget/${central.tpc.version}/REPO/</angularjs.repo.url>
 	</properties>
 	<modules>
 		<module>plugins</module>


### PR DESCRIPTION
JBIDE-22446 use central.tpc.version = 4.60.0.Final-SNAPSHOT, so that enforcer rule passes for TP version 4.60.0.Final-SNAPSHOT; also, should have moved to 4.60.0.Final-SNAPSHOT instead of Alpha1 about 3 months ago... oops\!