### PR TITLE
JBIDE-23304 NullPointerException in TagLibraryManager.getStaticTLD

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/TagLibraryManager.java
+++ b/plugins/org.jboss.tools.jst.web.kb/src/org/jboss/tools/jst/web/kb/taglib/TagLibraryManager.java
@@ -1,5 +1,5 @@
 /******************************************************************************* 
- * Copyright (c) 2009 - 2014 Red Hat, Inc. 
+ * Copyright (c) 2009 - 2016 Red Hat, Inc. 
  * Distributed under license by Red Hat, Inc. All rights reserved. 
  * This program is made available under the terms of the 
  * Eclipse Public License v1.0 which accompanies this distribution, 
@@ -98,7 +98,7 @@ public class TagLibraryManager {
 	        	}
 	        	if(id!=null) {
 	        		File file = convertUriToFile(id);
-	        		if(file.exists()) {
+	        		if(file != null && file.exists()) {
 	        			return file;
 	        		}
 	        	}


### PR DESCRIPTION
NPE is prevented (As TagLibraryManager.convertUriToFile(String) can return null, its result now is checked against null)

Signed-off-by: Victor Rubezhny <vrubezhny@redhat.com>