### PR TITLE
JBDS-4132 use latest tern 1.1.x CI build #1...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,8 +20,9 @@
 			https://github.com/jbdevstudio/jbdevstudio-website/blob/master/content/10.0/snapshots/updates/earlyaccess.properties/master/devstudio-earlyaccess.properties
 		
 		-->
-		<tern.version>1.1.0.201511082254</tern.version>
-		<tern.repo.url>${tern.reqs.url}/${tern.version}/</tern.repo.url>
+		<!-- <tern.version>1.1.0.201511082254</tern.version>
+		<tern.repo.url>${tern.reqs.url}/${tern.version}/</tern.repo.url> -->
+		<tern.repo.url>http://download.jboss.org/jbosstools/neon/snapshots/builds/tern.java-1.1.x/2016-10-28_15-14-41-B1/all/repo/</tern.repo.url>
 
 		<!-- 
 			Angular is on Early Access so after fetching a new version into 


### PR DESCRIPTION
JBDS-4132 use latest tern 1.1.x CI build #1 so local builds are also built against the latest tern bits used in devstudio rpm