### PR TITLE
[JBIDE-26031] - org.jboss.tools.jst.web.kb.FaceletValidatorExclude references validator ids that do not exist in org.eclipse.jst.jsf

### DIFF
--- a/tests/org.jboss.tools.jst.web.kb.test/META-INF/MANIFEST.MF
+++ b/tests/org.jboss.tools.jst.web.kb.test/META-INF/MANIFEST.MF
@@ -23,7 +23,8 @@ Require-Bundle: org.eclipse.ui,
  org.jboss.tools.common.validation,
  org.jboss.tools.common.base.test,
  org.eclipse.jface.text;bundle-version="3.7.0",
- org.jboss.tools.jst.jsp.base.test
+ org.jboss.tools.jst.jsp.base.test,
+ org.eclipse.jst.jsf.facelet.ui;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %Bundle-Vendor.0


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>