### PR TITLE
[JBIDE-26031] - org.jboss.tools.jst.web.kb.FaceletValidatorExclude references validator ids that do not exist in org.eclipse.jst.jsf

### DIFF
--- a/plugins/org.jboss.tools.jst.web.kb/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.jst.web.kb/META-INF/MANIFEST.MF
@@ -33,7 +33,8 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.jdom;bundle-version="1.1.1",
  org.eclipse.core.net;bundle-version="1.2.200",
  org.apache.commons.httpclient,
- org.apache.commons.io
+ org.apache.commons.io,
+ org.eclipse.jst.jsf.facelet.ui;bundle-version="1.3.0";resolution:=optional
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %providerName

--- a/plugins/org.jboss.tools.jst.web.kb/META-INF/MANIFEST.MF
+++ b/plugins/org.jboss.tools.jst.web.kb/META-INF/MANIFEST.MF
@@ -34,7 +34,7 @@ Require-Bundle: org.eclipse.ui;bundle-version="3.7.0",
  org.eclipse.core.net;bundle-version="1.2.200",
  org.apache.commons.httpclient,
  org.apache.commons.io,
- org.eclipse.jst.jsf.facelet.ui;bundle-version="1.3.0";resolution:=optional
+ org.eclipse.jst.jsf.facelet.ui;bundle-version="1.3.0"
 Bundle-ActivationPolicy: lazy
 Bundle-RequiredExecutionEnvironment: JavaSE-1.6
 Bundle-Vendor: %providerName


### PR DESCRIPTION
Signed-off-by: Jeff MAURY <jmaury@redhat.com>