### PR TITLE
JBIDE-26300 use tern 1.3.0.201803012316...

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 			https://github.com/jbdevstudio/jbdevstudio-website/blob/master/content/10.0/snapshots/updates/earlyaccess.properties/master/devstudio-earlyaccess.properties
 		
 		-->
-		<tern.version>1.2.1.201611022209</tern.version>
+		<tern.version>1.3.0.201803012316</tern.version>
 
 		<!-- 
 			Angular is on Early Access so after fetching a new version into 


### PR DESCRIPTION
JBIDE-26300 use tern 1.3.0.201803012316 instead of 1.2.1.201611022209 to fix CVE problems

Signed-off-by: nickboldt <nboldt@redhat.com>