### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,7 +47,7 @@ jobs:
 
     # Build and compile using Maven
     - name: Build/Compile and run unit tests
-      uses: GabrielBB/xvfb-action@v1
+      uses: GabrielBB/xvfb-action@86d97bde4a65fe9b290c0b3fb92c2c4ed0e5302d #v1
       with:
         run: >
           mvn clean verify -U -fae --settings build-ci/maven-settings.xml 

--- a/.github/workflows/publish_reports.yml
+++ b/.github/workflows/publish_reports.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           find . -name '*.zip' -exec sh -c 'unzip -d "${1%.*}" "$1"' _ {} \;
       - name: Publish aggregated tests reports
-        uses: scacap/action-surefire-report@v1
+        uses: scacap/action-surefire-report@4cbb611f23a9b5a030c73c2b32190a80983956ed #v1
         with:
           github_token: ${{secrets.GITHUB_TOKEN}}
           report_paths: '${{github.workspace}}/*test-reports/**/TEST-*.xml'


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
